### PR TITLE
store TTN configuration for each box

### DIFF
--- a/lib/controllers/boxesController.js
+++ b/lib/controllers/boxesController.js
@@ -127,6 +127,10 @@ const updateBox = function updateBox (req, res, next) {
       const { enabled, url, topic, decodeOptions, connectionOptions, messageFormat } = req.params.mqtt;
       qrys.push(box.set({ 'integrations.mqtt': { enabled, url, topic, decodeOptions, connectionOptions, messageFormat } }));
     }
+    if (typeof req.params.ttn !== 'undefined') {
+      const { app_id, dev_id, messageFormat, decodeOptions } = req.params.ttn;
+      qrys.push(box.set({ 'integrations.ttn': { app_id, dev_id, messageFormat, decodeOptions } }));
+    }
     if (typeof req.params.sensors !== 'undefined' && req.params.sensors.length > 0) {
       req.params.sensors.forEach(function (updatedsensor) {
         if (updatedsensor.deleted) {

--- a/lib/controllers/boxesController.js
+++ b/lib/controllers/boxesController.js
@@ -82,27 +82,27 @@ const updateBox = function updateBox (req, res, next) {
 
   const qrys = [];
   Box.findById(req._userParams.boxId).then(function (box) {
-    if (typeof req.params.name !== 'undefined' && req.params.name !== '') {
+    if (utils.isNonEmptyString(req.params.name)) {
       if (box.name !== req.params.name) {
         qrys.push(box.set({ name: req.params.name }));
       }
     }
-    if (typeof req.params.exposure !== 'undefined' && req.params.exposure !== '') {
+    if (utils.isNonEmptyString(req.params.exposure)) {
       if (box.exposure !== req.params.exposure) {
         qrys.push(box.set({ exposure: req.params.exposure }));
       }
     }
-    if (typeof req.params.grouptag !== 'undefined' && req.params.grouptag !== '') {
+    if (utils.isNonEmptyString(req.params.grouptag)) {
       if (box.grouptag !== req.params.grouptag) {
         qrys.push(box.set({ grouptag: req.params.grouptag }));
       }
     }
-    if (typeof req.params.weblink !== 'undefined' && req.params.weblink !== '') {
+    if (utils.isNonEmptyString(req.params.weblink)) {
       if (box.weblink !== req.params.weblink) {
         qrys.push(box.set({ weblink: req.params.weblink }));
       }
     }
-    if (typeof req.params.description !== 'undefined' && req.params.description !== '') {
+    if (utils.isNonEmptyString(req.params.description)) {
       if (box.description !== req.params.description) {
         qrys.push(box.set({ description: req.params.description }));
       }

--- a/lib/controllers/boxesController.js
+++ b/lib/controllers/boxesController.js
@@ -125,7 +125,7 @@ const updateBox = function updateBox (req, res, next) {
     }
     if (typeof req.params.mqtt !== 'undefined') {
       const { enabled, url, topic, decodeOptions, connectionOptions, messageFormat } = req.params.mqtt;
-      qrys.push(box.set({ 'mqtt': { enabled, url, topic, decodeOptions, connectionOptions, messageFormat } }));
+      qrys.push(box.set({ 'integrations.mqtt': { enabled, url, topic, decodeOptions, connectionOptions, messageFormat } }));
     }
     if (typeof req.params.sensors !== 'undefined' && req.params.sensors.length > 0) {
       req.params.sensors.forEach(function (updatedsensor) {

--- a/lib/decoding/transformAndValidateArray.js
+++ b/lib/decoding/transformAndValidateArray.js
@@ -21,12 +21,12 @@ const transformAndValidateArray = function (arr) {
         elem.sensor = undefined;
       }
 
-      if (typeof elem.sensor_id === 'undefined' || elem.sensor_id === '') {
+      if (!utils.isNonEmptyString(elem.sensor_id)) {
         reject(new Error(`missing sensor id for measurement ${JSON.stringify(elem)}`));
       }
 
       // value
-      if (typeof elem.value === 'undefined' || elem.value.toString().trim() === '') {
+      if (!utils.isNonEmptyString(elem.value)) {
         reject(new Error(`missing value for measurement ${JSON.stringify(elem)}`));
       }
       elem.value = sanitizeString(elem.value.toString());

--- a/lib/models/box.js
+++ b/lib/models/box.js
@@ -30,6 +30,7 @@ const mongoose = require('mongoose'),
   timestamp = require('mongoose-timestamp'),
   Schema = mongoose.Schema,
   sensorSchema = require('./sensor').schema,
+  integrations = require('./integrations'),
   products = require('../../products'),
   mqttClient = require('../mqtt'),
   Measurement = require('./measurement').model,
@@ -145,54 +146,10 @@ boxSchema.set('toJSON', {
     box._id = ret._id;
 
     if (options && options.includeSecrets) {
-      box.mqtt = ret.mqtt;
+      box.integrations = ret.integrations;
     }
 
     return box;
-  }
-});
-
-const isJSONParseableValidation = [function isJSONParseableValidator (value) {
-  if (value !== '') {
-    try {
-      JSON.parse(value);
-
-      return true;
-    } catch (err) {
-      return false;
-    }
-  }
-
-  return true;
-}, '{PATH} is not parseable as JSON'];
-
-const mqttSchema = new Schema({
-  enabled: { type: Boolean, default: false, required: true },
-  url: { type: String, trim: true, validate: [function (url) { return url === '' || url.startsWith('mqtt://') || url.startsWith('ws://'); }, '{PATH} must be either empty or start with mqtt:// or ws://'] },
-  topic: { type: String, trim: true },
-  messageFormat: { type: String, trim: true, enum: ['json', 'csv', 'application/json', 'text/csv', 'debug_plain', ''] },
-  decodeOptions: { type: String, trim: true, validate: isJSONParseableValidation },
-  connectionOptions: { type: String, trim: true, validate: isJSONParseableValidation }
-}, { _id: false });
-
-boxSchema.add({
-  mqtt: {
-    type: mqttSchema,
-    validate: [function (mqtt) {
-      if (mqtt.enabled === true) {
-        if (typeof mqtt.url === 'undefined' || mqtt.url === '') {
-          return false;
-        }
-        if (typeof mqtt.topic === 'undefined' || mqtt.topic === '') {
-          return false;
-        }
-        if (typeof mqtt.messageFormat === 'undefined' || mqtt.messageFormat === '') {
-          return false;
-        }
-      }
-
-      return true;
-    }, 'if {PATH} is true, url, topic and messageFormat should\'t be empty or invalid']
   }
 });
 
@@ -207,13 +164,11 @@ boxSchema.statics.initNew = function (req) {
     _id: mongoose.Types.ObjectId(),
     model: req.params.model,
     sensors: req.params.sensors,
-    mqtt: {
-      enabled: false
-    }
+    integrations: { mqtt: { enabled: false } }
   };
   if (req.params.mqtt) {
     const { enabled, url, topic, decodeOptions, connectionOptions, messageFormat } = req.params.mqtt;
-    boxData.mqtt = {
+    boxData.integrations.mqtt = {
       enabled, url, topic, decodeOptions, connectionOptions, messageFormat
     };
   }
@@ -259,7 +214,7 @@ boxSchema.statics.initNew = function (req) {
 };
 
 boxSchema.statics.connectMQTTBoxes = function () {
-  this.find({ 'mqtt.enabled': true })
+  this.find({ 'integrations.mqtt.enabled': true })
     .exec()
     .then(function (mqttBoxes) {
       mqttBoxes.forEach(mqttClient.connect);
@@ -272,7 +227,7 @@ boxSchema.statics.findAndPopulateBoxById = function (id, opts) {
 
   if (opts) {
     if (opts.includeSecrets) {
-      populationProps.mqtt = 1;
+      populationProps.integrations = 1;
     }
     if (opts.onlyLastMeasurements) {
       populationProps = {
@@ -498,40 +453,8 @@ boxSchema.statics.findMeasurementsOfBoxesStream = function (opts) {
     });
 };
 
-const checkMqttChanged = function (next) {
-  if (this.modifiedPaths && typeof this.modifiedPaths === 'function') {
-    this._mqttChanged = this.modifiedPaths().some(function (path) {
-      return path.includes('mqtt');
-    });
-  }
-  next();
-};
-
-const reconnectMqttOnChanged = function (box) {
-  if (box._mqttChanged === true) {
-    if (box.mqtt.enabled === true) {
-      console.log('mqtt credentials changed, reconnecting');
-      mqttClient.connect(box);
-    } else if (box.mqtt.enabled === false) {
-      mqttClient.disconnect(box);
-    }
-  }
-  box._mqttChanged = undefined;
-};
-
-// .pre('update', .. is a Query
-// .pre('save', .. looks like a Document
-
-boxSchema.pre('save', checkMqttChanged);
-//boxSchema.pre('update', checkMqttChanged);
-
-boxSchema.post('save', reconnectMqttOnChanged);
-//boxSchema.post('update', reconnectMqttOnChanged);
-
-boxSchema.pre('remove', function (next) {
-  mqttClient.disconnect(this);
-  next();
-});
+// add integrations Schema as box.integrations & register hooks
+integrations.addToSchema(boxSchema);
 
 const boxModel = mongoose.model('Box', boxSchema);
 

--- a/lib/models/integrations.js
+++ b/lib/models/integrations.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const mongoose = require('mongoose'),
+  Schema = mongoose.Schema,
+  mqttClient = require('../mqtt'),
+  utils = require('../utils'),
+  isJSONParseableValidation = [utils.isJSONParseable, '{PATH} is not parseable as JSON'];
+
+// MQTT broker integration data
+const mqttSchema = new Schema({
+  enabled: { type: Boolean, default: false, required: true },
+  url: { type: String, trim: true, validate: [function (url) { return url === '' || url.startsWith('mqtt://') || url.startsWith('ws://'); }, '{PATH} must be either empty or start with mqtt:// or ws://'] },
+  topic: { type: String, trim: true },
+  messageFormat: { type: String, trim: true, enum: ['json', 'csv', 'application/json', 'text/csv', 'debug_plain', ''] },
+  decodeOptions: { type: String, trim: true, validate: isJSONParseableValidation },
+  connectionOptions: { type: String, trim: true, validate: isJSONParseableValidation }
+}, { _id: false });
+
+// thethingsnetwork.org integration data
+const ttnSchema = new Schema({
+  dev_id: { type: String, trim: true, required: true },
+  app_id: { type: String, trim: true, required: true }
+}, { _id: false });
+
+const integrationSchema = new Schema({
+  mqtt: {
+    type: mqttSchema,
+    required: false,
+    validate: [function (mqtt) {
+      if (mqtt.enabled === true) {
+        if (typeof mqtt.url === 'undefined' || mqtt.url === '') {
+          return false;
+        }
+        if (typeof mqtt.topic === 'undefined' || mqtt.topic === '') {
+          return false;
+        }
+        if (typeof mqtt.messageFormat === 'undefined' || mqtt.messageFormat === '') {
+          return false;
+        }
+      }
+
+      return true;
+    }, 'if {PATH} is true, url, topic and messageFormat should\'t be empty or invalid']
+  },
+
+  ttn: {
+    type: ttnSchema,
+    required: false
+  }
+}, { _id: false });
+
+
+const addToSchema = (schema) => {
+  schema.add({ integrations: { type: integrationSchema } });
+
+  // flag whether mqtt options have changed
+  schema.pre('save', function (next) {
+    if (this.modifiedPaths && typeof this.modifiedPaths === 'function') {
+      this._mqttChanged = this.modifiedPaths().some(function (path) {
+        return path.includes('mqtt');
+      });
+    }
+    next();
+  });
+
+  // reconnect when mqtt option change was flagged
+  schema.post('save', function (box) {
+    if (box._mqttChanged === true) {
+      if (box.mqtt.enabled === true) {
+        console.log('mqtt credentials changed, reconnecting');
+        mqttClient.connect(box);
+      } else if (box.mqtt.enabled === false) {
+        mqttClient.disconnect(box);
+      }
+    }
+    box._mqttChanged = undefined;
+  });
+
+  // disconnect mqtt on removal
+  schema.pre('remove', function (next) {
+    mqttClient.disconnect(this);
+    next();
+  });
+};
+
+module.exports = {
+  schema: integrationSchema,
+  addToSchema,
+  // no model, bc its used as subdocument in boxSchema!
+};

--- a/lib/models/integrations.js
+++ b/lib/models/integrations.js
@@ -9,7 +9,7 @@ const mongoose = require('mongoose'),
 // MQTT broker integration data
 const mqttSchema = new Schema({
   enabled: { type: Boolean, default: false, required: true },
-  url: { type: String, trim: true, validate: [function (url) { return url === '' || url.startsWith('mqtt://') || url.startsWith('ws://'); }, '{PATH} must be either empty or start with mqtt:// or ws://'] },
+  url: { type: String, trim: true, validate: [function validMqttUri (url) { return url === '' || url.startsWith('mqtt://') || url.startsWith('ws://'); }, '{PATH} must be either empty or start with mqtt:// or ws://'] },
   topic: { type: String, trim: true },
   messageFormat: { type: String, trim: true, enum: ['json', 'csv', 'application/json', 'text/csv', 'debug_plain', ''] },
   decodeOptions: { type: String, trim: true, validate: isJSONParseableValidation },
@@ -31,7 +31,7 @@ const integrationSchema = new Schema({
   mqtt: {
     type: mqttSchema,
     required: false,
-    validate: [function (mqtt) {
+    validate: [function validMqttConfig (mqtt) {
       if (mqtt.enabled === true) {
         if (!utils.isNonEmptyString(mqtt.url)) {
           return false;
@@ -52,12 +52,12 @@ const integrationSchema = new Schema({
     type: ttnSchema,
     required: false,
     validate: [{
-      validator: function (ttn) {
+      validator: function validTTNMessageFormat (ttn) {
         return !(ttn.messageFormat === 'bytes' && !utils.isNonEmptyString(ttn.decodeOptions.profile));
       },
       msg: 'if messageFormat is "bytes", there must be a profile specified'
     }, {
-      validator: function (ttn) {
+      validator: function validTTNDecodeOptions (ttn) {
         return !(ttn.decodeOptions.profile === 'custom'
           && typeof ttn.decodeOptions.byteMask === 'undefined');
       },
@@ -67,13 +67,13 @@ const integrationSchema = new Schema({
 }, { _id: false });
 
 
-const addToSchema = function (schema) {
+const addToSchema = function addIntegrationsToSchema (schema) {
   schema.add({ integrations: { type: integrationSchema } });
 
   // flag whether mqtt options have changed
-  schema.pre('save', function (next) {
+  schema.pre('save', function integrationsPreSave (next) {
     if (this.modifiedPaths && typeof this.modifiedPaths === 'function') {
-      this._mqttChanged = this.modifiedPaths().some(function (path) {
+      this._mqttChanged = this.modifiedPaths().some(function eachPath (path) {
         return path.includes('mqtt');
       });
     }
@@ -81,7 +81,7 @@ const addToSchema = function (schema) {
   });
 
   // reconnect when mqtt option change was flagged
-  schema.post('save', function (box) {
+  schema.post('save', function integrationsPostSave (box) {
     if (box._mqttChanged === true) {
       if (box.integrations.mqtt.enabled === true) {
         console.log('mqtt credentials changed, reconnecting');
@@ -94,7 +94,7 @@ const addToSchema = function (schema) {
   });
 
   // disconnect mqtt on removal
-  schema.pre('remove', function (next) {
+  schema.pre('remove', function integrationsPostRemove (next) {
     mqttClient.disconnect(this);
     next();
   });

--- a/lib/models/integrations.js
+++ b/lib/models/integrations.js
@@ -52,12 +52,12 @@ const integrationSchema = new Schema({
     type: ttnSchema,
     required: false,
     validate: [{
-      validator (ttn) {
+      validator: function (ttn) {
         return !(ttn.messageFormat === 'bytes' && !utils.isNonEmptyString(ttn.decodeOptions.profile));
       },
       msg: 'if messageFormat is "bytes", there must be a profile specified'
     }, {
-      validator (ttn) {
+      validator: function (ttn) {
         return !(ttn.decodeOptions.profile === 'custom'
           && typeof ttn.decodeOptions.byteMask === 'undefined');
       },
@@ -67,7 +67,7 @@ const integrationSchema = new Schema({
 }, { _id: false });
 
 
-const addToSchema = (schema) => {
+const addToSchema = function (schema) {
   schema.add({ integrations: { type: integrationSchema } });
 
   // flag whether mqtt options have changed

--- a/lib/models/integrations.js
+++ b/lib/models/integrations.js
@@ -66,10 +66,10 @@ const addToSchema = (schema) => {
   // reconnect when mqtt option change was flagged
   schema.post('save', function (box) {
     if (box._mqttChanged === true) {
-      if (box.mqtt.enabled === true) {
+      if (box.integrations.mqtt.enabled === true) {
         console.log('mqtt credentials changed, reconnecting');
         mqttClient.connect(box);
-      } else if (box.mqtt.enabled === false) {
+      } else if (box.integrations.mqtt.enabled === false) {
         mqttClient.disconnect(box);
       }
     }

--- a/lib/models/integrations.js
+++ b/lib/models/integrations.js
@@ -19,7 +19,12 @@ const mqttSchema = new Schema({
 // thethingsnetwork.org integration data
 const ttnSchema = new Schema({
   dev_id: { type: String, trim: true, required: true },
-  app_id: { type: String, trim: true, required: true }
+  app_id: { type: String, trim: true, required: true },
+  messageFormat: { type: String, trim: true, enum: ['json', 'bytes'], required: true },
+  decodeOptions: {
+    profile: { type: String, trim: true, enum: ['custom', 'sensebox/home'] },
+    byteMask: { type: [Number] }
+  }
 }, { _id: false });
 
 const integrationSchema = new Schema({

--- a/lib/models/integrations.js
+++ b/lib/models/integrations.js
@@ -33,13 +33,13 @@ const integrationSchema = new Schema({
     required: false,
     validate: [function (mqtt) {
       if (mqtt.enabled === true) {
-        if (typeof mqtt.url === 'undefined' || mqtt.url === '') {
+        if (!utils.isNonEmptyString(mqtt.url)) {
           return false;
         }
-        if (typeof mqtt.topic === 'undefined' || mqtt.topic === '') {
+        if (!utils.isNonEmptyString(mqtt.topic)) {
           return false;
         }
-        if (typeof mqtt.messageFormat === 'undefined' || mqtt.messageFormat === '') {
+        if (!utils.isNonEmptyString(mqtt.messageFormat)) {
           return false;
         }
       }
@@ -50,7 +50,19 @@ const integrationSchema = new Schema({
 
   ttn: {
     type: ttnSchema,
-    required: false
+    required: false,
+    validate: [{
+      validator (ttn) {
+        return !(ttn.messageFormat === 'bytes' && !utils.isNonEmptyString(ttn.decodeOptions.profile));
+      },
+      msg: 'if messageFormat is "bytes", there must be a profile specified'
+    }, {
+      validator (ttn) {
+        return !(ttn.decodeOptions.profile === 'custom'
+          && typeof ttn.decodeOptions.byteMask === 'undefined');
+      },
+      msg: 'if decodeOptions.profile is "custom" there must be byte mask specified'
+    }]
   }
 }, { _id: false });
 

--- a/lib/mqtt/index.js
+++ b/lib/mqtt/index.js
@@ -40,7 +40,7 @@ const _connect = function (box, maxRetries) {
   let errRetries = maxRetries,
     closeRetries = maxRetries;
 
-  const client = mqtt.connect(box.mqtt.url, connectionOptions);
+  const client = mqtt.connect(box.integrations.mqtt.url, connectionOptions);
   client.reconnecting = true;
 
   return new Promise(function (resolve, reject) {
@@ -74,7 +74,7 @@ const _connect = function (box, maxRetries) {
 
     client.on('connect', function () {
       console.log('connected mqtt for box', box._id);
-      client.subscribe(box.mqtt.topic, function (err) {
+      client.subscribe(box.integrations.mqtt.topic, function (err) {
         if (err) {
           return reject(err);
         }
@@ -89,15 +89,16 @@ const _connect = function (box, maxRetries) {
 const connect = function (box) {
   // disconnect any running connections before reconnecting..
   disconnect(box);
-  if (box.mqtt && box.mqtt.url !== '') {
-    const handler = decodeHandlers[box.mqtt.messageFormat];
+  if (box.integrations.mqtt && box.integrations.mqtt.url !== '') {
+    const mqttCfg = box.integrations.mqtt;
+    const handler = decodeHandlers[mqttCfg.messageFormat];
 
-    if (box.mqtt.url && box.mqtt.topic && handler) {
+    if (mqttCfg.url && mqttCfg.topic && handler) {
       _connect(box, 5)
         .then(function (client) {
           let decodeOptions;
           try {
-            decodeOptions = JSON.parse(box.mqtt.decodeOptions);
+            decodeOptions = JSON.parse(mqttCfg.decodeOptions);
           } catch (e) {
             console.log('warn: mqtt decode options of box', box._id, 'not parseable');
           }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -81,12 +81,12 @@ const softwareRevision = (function () {
   try {
     /* eslint-disable global-require */
     const parts = require('fs')
-      .readFileSync(__dirname + '/../revision')
+      .readFileSync(`${__dirname}/../revision`)
       .toString()
       .split(' ');
     /* eslint-enable global-require */
     parts[1] = new Date(parseInt(parts[1], 10) * 1000).toISOString();
-    
+
     return `${parts[0]} ${parts[1]} ${parts[2]}`;
   } catch (err) {
     return 'unkown revision';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -25,7 +25,7 @@ if (config.honeybadger_apikey && config.honeybadger_apikey !== '') {
  */
 
 // time parsing function used throughout the api
-const parseTimestamp = function (timestamp) {
+const parseTimestamp = function parseTimestamp (timestamp) {
   if (timestamp instanceof Date) {
     return moment.utc(timestamp);
   }
@@ -34,7 +34,7 @@ const parseTimestamp = function (timestamp) {
 };
 
 // http://stackoverflow.com/a/23453651
-const sanitizeString = function (str) {
+const sanitizeString = function sanitizeString (str) {
   str = str.replace(/[^a-z0-9áéíóúñü \.,_-]/gim, '');
 
   return str.trim();
@@ -42,7 +42,7 @@ const sanitizeString = function (str) {
 
 // checks if the timestamp is not too far in the future
 // returns true or false
-const timeIsValid = function (timestamp) {
+const timeIsValid = function timeIsValid (timestamp) {
   const nowPlusOneMinute = moment.utc().add(1, 'minutes');
   if (!moment.isMoment(timestamp)) {
     timestamp = parseTimestamp(timestamp);
@@ -52,12 +52,12 @@ const timeIsValid = function (timestamp) {
 };
 
 // returns now as UTC JavaScript Date Object
-const utcNowDate = function () {
+const utcNowDate = function utcNowDate () {
   return moment.utc().toDate();
 };
 
 // use this function to retry if a connection cannot be established immediately
-const connectWithRetry = function (success) {
+const connectWithRetry = function connectWithRetry (success) {
   return mongoose.connect(config.dbconnectionstring, {
     keepAlive: 1
   }, function (err) {
@@ -71,7 +71,7 @@ const connectWithRetry = function (success) {
   });
 };
 
-const postToSlack = function (text) {
+const postToSlack = function postToSlack (text) {
   if (config.slack_url) {
     request.post({ url: config.slack_url, json: { text: text } });
   }
@@ -93,7 +93,7 @@ const softwareRevision = (function () {
   }
 })();
 
-const isJSONParseable = function (value) {
+const isJSONParseable = function isJSONParseable (value) {
   if (value !== '') {
     try {
       JSON.parse(value);
@@ -107,7 +107,7 @@ const isJSONParseable = function (value) {
   return true;
 };
 
-const isNonEmptyString = function (val) {
+const isNonEmptyString = function isNonEmptyString (val) {
   return !(typeof val === 'undefined' || val === '');
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -93,7 +93,7 @@ const softwareRevision = (function () {
   }
 })();
 
-const isJSONParseable = value => {
+const isJSONParseable = function (value) {
   if (value !== '') {
     try {
       JSON.parse(value);
@@ -107,7 +107,7 @@ const isJSONParseable = value => {
   return true;
 };
 
-const isNonEmptyString = val => {
+const isNonEmptyString = function (val) {
   return !(typeof val === 'undefined' || val === '');
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -107,11 +107,16 @@ const isJSONParseable = value => {
   return true;
 };
 
+const isNonEmptyString = val => {
+  return !(typeof val === 'undefined' || val === '');
+};
+
 module.exports = {
   config,
   Honeybadger,
   parseTimestamp,
   isJSONParseable,
+  isNonEmptyString,
   timeIsValid,
   sanitizeString,
   utcNowDate,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -93,10 +93,25 @@ const softwareRevision = (function () {
   }
 })();
 
+const isJSONParseable = value => {
+  if (value !== '') {
+    try {
+      JSON.parse(value);
+
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
 module.exports = {
   config,
   Honeybadger,
   parseTimestamp,
+  isJSONParseable,
   timeIsValid,
   sanitizeString,
   utcNowDate,

--- a/tests/data/getUserBoxesSchema.js
+++ b/tests/data/getUserBoxesSchema.js
@@ -96,30 +96,49 @@ module.exports = {
               '_id': {
                 'type': 'string'
               },
-              'mqtt': {
+              'integrations': {
                 'type': 'object',
                 'properties': {
-                  'url': {
-                    'type': 'string'
+                  'mqtt': {
+                    'type': 'object',
+                    'properties': {
+                      'url': {
+                        'type': 'string'
+                      },
+                      'topic': {
+                        'type': 'string'
+                      },
+                      'decodeOptions': {
+                        'type': 'string'
+                      },
+                      'connectionOptions': {
+                        'type': 'string'
+                      },
+                      'messageFormat': {
+                        'type': 'string'
+                      },
+                      'enabled': {
+                        'type': 'boolean'
+                      }
+                    },
+                    'required': [
+                      'enabled'
+                    ]
                   },
-                  'topic': {
-                    'type': 'string'
-                  },
-                  'decodeOptions': {
-                    'type': 'string'
-                  },
-                  'connectionOptions': {
-                    'type': 'string'
-                  },
-                  'messageFormat': {
-                    'type': 'string'
-                  },
-                  'enabled': {
-                    'type': 'boolean'
+                  'ttn': {
+                    'type': 'object',
+                    'properties': {
+                      'dev_id': {
+                        'type': 'string'
+                      },
+                      'app_id': {
+                        'type': 'string'
+                      }
+                    },
                   }
                 },
                 'required': [
-                  'enabled'
+                  'mqtt'
                 ]
               }
             },
@@ -132,7 +151,7 @@ module.exports = {
               'loc',
               'sensors',
               '_id',
-              'mqtt'
+              'integrations'
             ]
           }
         }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -908,6 +908,31 @@ describe('openSenseMap API', function () {
         });
     });
 
+    it('should allow to configure TTN via PUT', function () {
+      const update_payload = { ttn: { app_id: 'myapp', dev_id: 'mydevice', messageFormat: 'bytes', decodeOptions: {
+        profile: 'custom', byteMask: [2, 2, 1, 1]
+      } } };
+
+      return chakram.put(`${BASE_URL}/boxes/${boxIds[1]}`, update_payload, { headers: { 'Authorization': `Bearer ${jwt2}` } })
+        .then(function (response) {
+          expect(response).to.have.status(200);
+
+          return chakram.wait();
+        });
+    });
+
+    it('should reject invalid TTN configuration', function () {
+      const update_payload = { ttn: { messageFormat: 'bytes', decodeOptions: { profile: 'custom', byteMask: null } } };
+
+      return chakram.put(`${BASE_URL}/boxes/${boxIds[1]}`, update_payload, { headers: { 'Authorization': `Bearer ${jwt2}` } })
+        .then(function (response) {
+          expect(response).to.have.status(422);
+          expect(response.body.message).to.equal('validation failed');
+
+          return chakram.wait();
+        });
+    });
+
     it('should allow to enable mqtt via PUT', function () {
       const update_payload = { mqtt: { enabled: true, url: 'mqtt://mosquitto', topic: 'mytopic', messageFormat: 'json', decodeOptions: '{}', connectionOptions: '{}' } };
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -325,7 +325,7 @@ describe('openSenseMap API', function () {
           expect(response).to.have.header('content-type', 'application/json; charset=utf-8');
           expect(response).to.have.schema(senseBoxSchema);
 
-          expect(response.body).to.not.have.keys('mqtt');
+          expect(response.body).to.not.have.keys('integrations');
 
           return chakram.wait();
         });
@@ -349,7 +349,7 @@ describe('openSenseMap API', function () {
           expect(response).to.have.header('content-type', 'application/json; charset=utf-8');
           expect(response).to.have.schema(senseBoxSchema);
 
-          expect(response.body).to.not.have.keys('mqtt');
+          expect(response.body).to.not.have.keys('integrations');
 
           return chakram.wait();
         });
@@ -381,7 +381,7 @@ describe('openSenseMap API', function () {
           expect(response).to.have.header('content-type', 'application/json; charset=utf-8');
           expect(response).to.have.schema(senseBoxSchema);
 
-          expect(response.body).to.not.have.keys('mqtt');
+          expect(response.body).to.not.have.keys('integrations');
 
           return chakram.wait();
         });
@@ -392,7 +392,7 @@ describe('openSenseMap API', function () {
         .then(function (response) {
           expect(response).to.have.status(200);
           expect(response).to.have.schema(getUserBoxesSchema);
-          expect(response).to.comprise.of.json({ data: { boxes: [ { mqtt: { enabled: false } } ] } });
+          expect(response).to.comprise.of.json('data.boxes.0.integrations.mqtt', { enabled: false });
 
           return chakram.wait();
         });
@@ -525,7 +525,7 @@ describe('openSenseMap API', function () {
           expect(response).to.have.header('content-type', 'application/json; charset=utf-8');
           expect(response).to.have.schema(senseBoxSchema);
 
-          expect(response.body).to.not.have.keys('mqtt');
+          expect(response.body).to.not.have.keys('integrations');
 
           return chakram.wait();
         });
@@ -919,7 +919,8 @@ describe('openSenseMap API', function () {
         })
         .then(function (response) {
           expect(response).to.have.schema(getUserBoxesSchema);
-          expect(response).to.comprise.of.json({ data: { boxes: [ { mqtt: { enabled: true } } ] } });
+          // for some reason the second created box is returned first..?
+          expect(response).to.comprise.of.json('data.boxes.0.integrations.mqtt', { enabled: true });
 
           return chakram.wait();
         });


### PR DESCRIPTION
Adds the property `integrations: { mqtt, ttn }` to `box`.

- the schema for `integrations.ttn` is:
    ```js
    {
      // as registered in thethingsnetwork 
      app_id: String,
      dev_id: String,

      // json: data comes in `payload` as JSON in the API's currently consumable JSON schema
      // bytes: data comes in `payload_raw` as byte string, which gets decoded according to a profile
      messageFormat: Enum['json', 'bytes'],
      decodeOptions: {
        // custom: bytes get decoded through a custom byte mask specified in byteMask
        // sensebox/home: the currently only predefined configuration as implemented in
        //                lora/ttnPayloadFunctionExample.js
        profile: Enum['custom', 'sensebox/home'],
        // defines the amount of bytes to consume for each sensor. each element matches one sensor in `box.sensors` in the same order
        byteMask: Array[Number]
      }
    }
    ```

- Breaks the response schema for `GET /users/me/boxes`, as `box.mqtt` is not available anymore.

- The payload format for `PUT /boxes/:boxId` stays as is, in order to avoid breaking changes:
    MQTT & TTN are configured through `{ mqtt: {...}, ttn: {...} }`