### PR TITLE
swap pm10 and pm2.5 (fixes #88)

### DIFF
--- a/files/template_home_wifi_feinstaub/template_home_wifi_feinstaub.ino
+++ b/files/template_home_wifi_feinstaub/template_home_wifi_feinstaub.ino
@@ -260,8 +260,8 @@ void loop() {
     pm25 = 0;
     pm10 = 0;
   }
-  addValue(pm25);
   addValue(pm10);
+  addValue(pm25);
 
   submitValues();
 


### PR DESCRIPTION
see #88. I checked, only the WiFi sketch is affected.

We should think about swapping these sensorIds of boxes that were already registered with this sketch.

(untested) migration:

```js
var boxIter = db.boxes.find({
  model: 'homeWifiFeinstaub',
  createdAt: { $lt: ISODate('2017-06-10T19:13:04.319Z') } // change to time when fix goes live
});

var boxesBulk = db.boxes.initializeUnorderedBulkOp();

// swap sensorIds for PM10 and PM2.5 sensors
while (boxIter.hasNext()) {
  var box = boxIter.next();

  var pm10ID = box.sensors[5]._id, // old sketch sends pm25 to this
      pm25ID = box.sensors[6]._id; // old sketch sends pm10 to this

  boxesBulk.update(
    { _id: box._id },
    { $set: { 'sensors.5._id': pm25ID, 'sensors.6._id': pm10ID } }
  );
}

boxesBulk.execute();
```