### PR TITLE
Mobile followup

### DIFF
--- a/lib/controllers/boxesController.js
+++ b/lib/controllers/boxesController.js
@@ -159,6 +159,8 @@ const getMeasurements = function getMeasurements (req, res, next) {
  * being an array with the timestamp for each coordinate.
  *
  * @apiParam {String=json,geojson} format=json
+ * @apiParam {ISO8601Date} [from-date] Beginning date of location timestamps (default: 48 hours ago from now)
+ * @apiParam {ISO8601Date} [to-date] End date of location timstamps (default: now)
  * @apiUse BoxIdParam
  *
  * @apiSuccessExample {application/json} Example response for :format=json
@@ -178,6 +180,13 @@ const getBoxLocations = function getBoxLocations (req, res, next) {
         return next(new restify.NotFoundError('box not found'));
       }
 
+      const locs = box.locations.filter(function (loc) {
+        return (
+          req._userParams['from-date'].isSameOrBefore(loc.timestamp) &&
+          req._userParams['to-date'].isSameOrAfter(loc.timestamp)
+        );
+      });
+
       if (format === 'geojson') {
         const geo = {
           type: 'Feature',
@@ -185,13 +194,14 @@ const getBoxLocations = function getBoxLocations (req, res, next) {
           properties: { timestamps: [] }
         };
 
-        for (const l of box.locations) {
+        for (const l of locs) {
           geo.geometry.coordinates.push(l.coordinates);
           geo.properties.timestamps.push(l.timestamp);
         }
+
         res.send(200, geo);
       } else {
-        res.send(200, box.locations);
+        res.send(200, locs);
       }
     })
     .catch(function (error) {
@@ -995,6 +1005,7 @@ module.exports = {
   getMeasurements,
   getBoxLocations: [
     retrieveParameter('format', 'String', 'json', ['json', 'geojson']),
+    parseAndValidateTimeParams,
     getBoxLocations
   ],
   getBoxArea,

--- a/lib/controllers/boxesController.js
+++ b/lib/controllers/boxesController.js
@@ -503,6 +503,8 @@ const postNewMeasurement = function postNewMeasurement (req, res, next) {
  * sensorID,value
  * anotherSensorId,value,ISO8601-timestamp
  * sensorIDtheThird,value
+ * anotherSensorId,value,ISO8601-timestamp,longitude,latitude
+ * anotherSensorId,value,ISO8601-timestamp,longitude,latitude,height
  * ...
  * @apiParamExample {application/json} Luftdaten Format:
  * {

--- a/lib/decoding/csvHandler.js
+++ b/lib/decoding/csvHandler.js
@@ -26,10 +26,16 @@ module.exports = {
         }
 
         if (line.length !== 0) {
-          if (line.length === 2 || line.length === 3) {
+          if (line.length >= 2 && line.length <= 6) {
             const measurement = { sensor_id: line.shift() };
             measurement.value = line.shift();
             measurement.createdAt = line.shift();
+            if (line.length >= 2) {
+              measurement.location = {};
+              measurement.location.lng = parseFloat(line.shift());
+              measurement.location.lat = parseFloat(line.shift());
+              measurement.location.height = parseFloat(line.shift());
+            }
             measurementsArray.push(measurement);
           } else {
             throw new Error(`illegal line '${line.join(',')}'`);

--- a/lib/decoding/validators.js
+++ b/lib/decoding/validators.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { parseTimestamp, timeIsValid, isNonEmptyString, utcNowDate } = require('../utils'),
+const { parseTimestamp, timeIsValid, isNonEmptyString, isNumeric, utcNowDate } = require('../utils'),
   { mongoose } = require('../db');
 
 const isNumber = function isNumber (n) {
@@ -75,11 +75,11 @@ const transformAndValidateMeasurements = function transformAndValidateMeasuremen
  */
 const transformAndValidateCoords = function transformAndValidateCoords (coords) {
   let { lng, lat, height } = coords || {};
-  if (coords && coords.constructor === Array) {
+  if (Array.isArray(coords)) {
     [ lng, lat, height ] = coords;
   }
 
-  if (typeof lng !== 'number' || typeof lat !== 'number') {
+  if (!isNumeric(lng) || !isNumeric(lat)) {
     throw new Error(`missing latitude or longitude in location ${JSON.stringify(coords)}`);
   }
 
@@ -93,7 +93,7 @@ const transformAndValidateCoords = function transformAndValidateCoords (coords) 
     Math.round(lat * 10e6) / 10e6
   ];
 
-  if (typeof height === 'number') {
+  if (isNumeric(height)) {
     result.push(Math.round(height * 10e3) / 10e3);
   }
 

--- a/lib/models/box.js
+++ b/lib/models/box.js
@@ -482,15 +482,21 @@ boxSchema.methods.saveMeasurementsArray = function (measurements) {
 
   // iterate over all new measurements to check for location updates
   let m = 0;
-  const newLocations = [], promises = [],
-    findEarlierLoc = (loc) => measurements[m].createdAt.isAfter(loc.timestamp);
+  const newLocations = [], promises = [];
+  const findEarlierLoc = function findEarlierLoc (locations, measurement) {
+    for (let i = locations.length - 1; i >= 0; i--) {
+      if (measurement.createdAt.isAfter(locations[i].timestamp)) {
+        return locations[i];
+      }
+    }
+  };
 
   while (m < measurements.length) {
 
     // find the location in both new and existing locations, which is newest
     // in relation to the measurent time. (box.locations is sorted by date)
-    const earlierLocOld = box.locations.find(findEarlierLoc),
-      earlierLocNew = newLocations.find(findEarlierLoc);
+    const earlierLocOld = findEarlierLoc(box.locations, measurements[m]),
+      earlierLocNew = findEarlierLoc(newLocations, measurements[m]);
 
     let loc = earlierLocOld;
     if (

--- a/lib/models/box.js
+++ b/lib/models/box.js
@@ -382,19 +382,8 @@ boxSchema.methods.updateLocation = function updateLocation (coords, timestamp) {
       box.currentLocation = newLoc;
     }
 
-    const promises = [box.save()];
-
-    // need to update location refs of measurements with time between
-    // newLoc.timestamp and laterLoc.timestamp
-    if (prevLoc) {
-      promises.push(
-        Measurement.where({ 'location.coordinates': prevLoc.coordinates, createdAt: { $gte: time } })
-          .setOptions({ multi: true })
-          .update({ location: { type: newLoc.type, coordinates: newLoc.coordinates } })
-      );
-    }
-
-    return Promise.all(promises).then(() => Promise.resolve(newLoc));
+    return box.save()
+      .then(() => Promise.resolve(newLoc));
   }
 
   // coords and timestamps are equal or not provided
@@ -482,7 +471,7 @@ boxSchema.methods.saveMeasurementsArray = function (measurements) {
 
   // iterate over all new measurements to check for location updates
   let m = 0;
-  const newLocations = [], promises = [];
+  const newLocations = [];
   const findEarlierLoc = function findEarlierLoc (locations, measurement) {
     for (let i = locations.length - 1; i >= 0; i--) {
       if (measurement.createdAt.isAfter(locations[i].timestamp)) {
@@ -526,25 +515,6 @@ boxSchema.methods.saveMeasurementsArray = function (measurements) {
       };
 
       newLocations.push(loc);
-
-      // update & save measurements after this location and before next timestamp.
-      if (earlierLocOld) {
-        const measureQuery = {
-          'location.coordinates': earlierLocOld.coordinates,
-          'createdAt': { '$gte': measurements[m].createdAt }
-        };
-
-        if (measurements[m + 1]) {
-          measureQuery['createdAt']['$lt'] = measurements[m + 1].createdAt;
-        }
-
-        promises.push(
-          Measurement
-            .where(measureQuery)
-            .setOptions({ multi: true })
-            .update({ location: { type: 'Point', coordinates: loc.coordinates }})
-        );
-      }
     }
 
     // apply location to all measurements with missing or equal location.
@@ -557,12 +527,8 @@ boxSchema.methods.saveMeasurementsArray = function (measurements) {
     );
   }
 
-  // update existing measurements
-  return Promise.all(promises)
-    .then(function () {
-      // save new measurements
-      return Measurement.insertMany(measurements);
-    })
+  // save new measurements
+  return Measurement.insertMany(measurements)
     .then(function () {
       const updateQuery = {};
 

--- a/lib/models/box.js
+++ b/lib/models/box.js
@@ -522,15 +522,23 @@ boxSchema.methods.saveMeasurementsArray = function (measurements) {
       newLocations.push(loc);
 
       // update & save measurements after this location and before next timestamp.
-      promises.push(
-        Measurement
-          .where({
-            'location.coordinates': earlierLocOld.coordinates,
-            'createdAt': { $gte: measurements[m].createdAt }
-          })
-          .setOptions({ multi: true })
-          .update({ location: loc._id })
-      );
+      if (earlierLocOld) {
+        const measureQuery = {
+          'location.coordinates': earlierLocOld.coordinates,
+          'createdAt': { '$gte': measurements[m].createdAt }
+        };
+
+        if (measurements[m + 1]) {
+          measureQuery['createdAt']['$lt'] = measurements[m + 1].createdAt;
+        }
+
+        promises.push(
+          Measurement
+            .where(measureQuery)
+            .setOptions({ multi: true })
+            .update({ location: { type: 'Point', coordinates: loc.coordinates }})
+        );
+      }
     }
 
     // apply location to all measurements with missing or equal location.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -88,6 +88,11 @@ const isNonEmptyString = function isNonEmptyString (val) {
   return !(typeof val === 'undefined' || val === '');
 };
 
+// https://stackoverflow.com/questions/18082/validate-decimal-numbers-in-javascript-isnumeric
+const isNumeric = function isNumeric (n) {
+  return !isNaN(parseFloat(n)) && isFinite(n);
+};
+
 const redactEmail = function redactEmail (email) {
   /* eslint-disable prefer-const */
   let [ name = '', domain = '' ] = email.split('@');
@@ -108,6 +113,7 @@ module.exports = {
   parseTimestamp,
   isJSONParseable,
   isNonEmptyString,
+  isNumeric,
   timeIsValid,
   utcNowDate,
   postToSlack,


### PR DESCRIPTION
- fixes 2 bugs
- changes behavior for location updates at measurement insertion, to simplify the function
    - the rare (?) use case is not supported anymore, where *some* measurements provide a location, while others don't AND when they are sent unordered by time. details in commit message
- adds location fields to csv measurement handler
- adds a time filter to /boxes/:boxId/locations