### PR TITLE
support new ttn-integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # openSenseMap API Changelog
 
 ## Unreleased
+
+## v3
 - Avoid moment usage in ClassifyTransformer
+- Use @sensebox/opensensemap-api-models v0.0.8
 
 ## v2
 - Initial Release after splitting api and models

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,7 +10,7 @@
     "Norwin Roosen"
   ],
   "dependencies": {
-    "@sensebox/opensensemap-api-models": "0.0.7",
+    "@sensebox/opensensemap-api-models": "0.0.8",
     "@turf/area": "^4.6.0",
     "@turf/bbox": "^4.6.0",
     "@turf/centroid": "^4.6.1",

--- a/packages/models/CHANGELOG.md
+++ b/packages/models/CHANGELOG.md
@@ -1,6 +1,8 @@
 # @sensebox/opensensemap-api-models Changelog
 
 ## Unreleased
+
+## v0.0.8
 - Expand .npmignore
 
 ## v0.0.7

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sensebox/opensensemap-api-models",
   "description": "openSenseMap data models and database connection",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Support the new device registration concept (see https://github.com/sensebox/ttn-osem-integration/issues/8) once https://github.com/sensebox/ttn-osem-integration/pull/13 is merged.

- [ ] (models) add optional `box.integrations.ttn.dev_eui` to model
- [ ] (models) make `box.integrations.ttn.dev_id` optional, defaulting to `box._id`
- [ ] (models) ensure combination of `app_id, dev_id, port` is unique
- [ ] (api) add hook in `POST /boxes`, `PUT /boxes/:boxId` to register devices via TTN hook (`GET ttnintegration/v1.1/ttndevice/:boxId`) and provide results in the response
