### PR TITLE
Possibility to send WiFi credentials for sketch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## v6
+- Use @sensebox/opensensemap-api-models v0.0.11
+- Support for `hackAIR` devices
+- Support for `bbox` query parameter on `/boxes`. Closes #174
+
 ## v5
 - Allow users to delete their box images by sending `deleteImage: true`
 - Change Forbidden Response for invalid JWT authorization

--- a/packages/api/lib/controllers/boxesController.js
+++ b/packages/api/lib/controllers/boxesController.js
@@ -414,7 +414,7 @@ const getSketch = async function getSketch (req, res, next) {
   res.header('Content-Type', 'text/plain; charset=utf-8');
   try {
     const box = await Box.findBoxById(req._userParams.boxId, { populate: false, lean: false });
-    res.send(box.getSketch({ serialPort: req._userParams.serialPort }));
+    res.send(box.getSketch({ serialPort: req._userParams.serialPort, ssid: req._userParams.ssid, password: req._userParams.password }));
   } catch (err) {
     handleError(err, next);
   }
@@ -459,7 +459,9 @@ module.exports = {
   getSketch: [
     retrieveParameters([
       { predef: 'boxId', required: true },
-      { name: 'serialPort', dataType: 'String', allowedValues: ['Serial1', 'Serial2'] }
+      { name: 'serialPort', dataType: 'String', allowedValues: ['Serial1', 'Serial2'] },
+      { name: 'ssid', dataType: 'StringWithEmpty' },
+      { name: 'password', dataType: 'StringWithEmpty' }
     ]),
     checkPrivilege,
     getSketch

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,7 +10,7 @@
     "Norwin Roosen"
   ],
   "dependencies": {
-    "@sensebox/opensensemap-api-models": "^0.0.11-beta.2",
+    "@sensebox/opensensemap-api-models": "^0.0.11",
     "@turf/area": "^4.6.0",
     "@turf/bbox": "^4.6.0",
     "@turf/centroid": "^4.6.1",

--- a/packages/models/CHANGELOG.md
+++ b/packages/models/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## v0.0.11
+- **BREAKING CHANGE**: `/boxes` sensor does not contain `lastMeasurement` anymore
+- introduce `minimal` parameter to reduce payload on `/boxes` #164
+- introduce `lastMeasurementAt` in box schema and update field every time new measurement is stored to avoid additional databse lookup. Fixes #148
+- Uploading a single measurement with a specified time. Fixes #169
+- Update @sensebox/node-sketch-templater to 1.3.0
+- Add new LoRa model (`homeV2Lora`). Fixes #165
+- add `bbox` parameter to `/boxes` route
+- add `hackAir` decoding handler
+
 ## v0.0.11-beta.2
 
 ## v0.0.11-beta.1

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "@sensebox/osem-protos": "^1.1.0",
-    "@sensebox/sketch-templater": "^1.4.0-beta.3",
+    "@sensebox/sketch-templater": "^1.4.0-beta.4",
     "bcrypt": "^1.0.2",
     "bunyan": "^1.8.12",
     "config": "^1.29.2",

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "@sensebox/osem-protos": "^1.1.0",
-    "@sensebox/sketch-templater": "^1.4.0-beta.4",
+    "@sensebox/sketch-templater": "^1.4.0",
     "bcrypt": "^1.0.2",
     "bunyan": "^1.8.12",
     "config": "^1.29.2",

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sensebox/opensensemap-api-models",
   "description": "openSenseMap data models and database connection",
-  "version": "0.0.11-beta.2",
+  "version": "0.0.11",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "@sensebox/osem-protos": "^1.1.0",
-    "@sensebox/sketch-templater": "^1.3.0",
+    "@sensebox/sketch-templater": "^1.4.0-beta.3",
     "bcrypt": "^1.0.2",
     "bunyan": "^1.8.12",
     "config": "^1.29.2",

--- a/packages/models/src/box/box.js
+++ b/packages/models/src/box/box.js
@@ -219,7 +219,6 @@ boxSchema.statics.initNew = function ({
   model,
   sensors,
   sensorTemplates,
-  serialPort,
   mqtt: {
     enabled, url, topic, decodeOptions: mqttDecodeOptions, connectionOptions, messageFormat
   } = { enabled: false },
@@ -799,10 +798,13 @@ boxSchema.methods.updateSensors = function updateSensors (sensors) {
   }
 };
 
-boxSchema.methods.getSketch = function getSketch ({ encoding, serialPort } = {}) {
+boxSchema.methods.getSketch = function getSketch ({ encoding, serialPort, ssid, password } = {}) {
   if (serialPort) {
     this.serialPort = serialPort;
   }
+
+  this.ssid = ssid;
+  this.password = password;
 
   return templateSketcher.generateSketch(this, { encoding });
 };

--- a/packages/models/src/user/mails.js
+++ b/packages/models/src/user/mails.js
@@ -24,7 +24,7 @@ if (config.get('mailer.url')) {
         },
         attachment: {
           filename: 'senseBox.ino',
-          contents: box.getSketch({ encoding: 'base64', serialPort: box.serialPort })
+          contents: box.getSketch({ encoding: 'base64', serialPort: box.serialPort, ssid: '', password: '' })
         }
       };
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,10 +19,10 @@
   resolved "https://registry.yarnpkg.com/@sensebox/osem-protos/-/osem-protos-1.1.0.tgz#a7de8bc6be867953f1309181a012063c23299e79"
   integrity sha512-H+nUVcWlT0dvIqfJnYHuX9JBcCkP1ZKGE5YTRNWPbAEdZ11h+srpQsmeI58wK5hJcdukaZAjc4Dy96IeGM77aA==
 
-"@sensebox/sketch-templater@^1.4.0-beta.4":
-  version "1.4.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@sensebox/sketch-templater/-/sketch-templater-1.4.0-beta.4.tgz#76cd8d7faa49bde4f63a69d39c073002d881e3b1"
-  integrity sha512-iYb6P/92wsc0CL3hHVlOgT5cvPkub+wkCCcWz8ON+hWcdsyvqjhLLVsrpxj/p5H2GRwY3lZA8/55doBlTjZydw==
+"@sensebox/sketch-templater@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@sensebox/sketch-templater/-/sketch-templater-1.4.0.tgz#f6b91651a372b5961dcae9c1490916953fc7b092"
+  integrity sha512-vRI6h1/UKxQ/suIu7ZTscYpfFQdroyeItX5NslA/4ZWtDrq0bDWD7L/I7VXkLgpYkc090D8GradF8heHaScgBQ==
   dependencies:
     config "^1.29.2"
     dedent "^0.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,10 +19,10 @@
   resolved "https://registry.yarnpkg.com/@sensebox/osem-protos/-/osem-protos-1.1.0.tgz#a7de8bc6be867953f1309181a012063c23299e79"
   integrity sha512-H+nUVcWlT0dvIqfJnYHuX9JBcCkP1ZKGE5YTRNWPbAEdZ11h+srpQsmeI58wK5hJcdukaZAjc4Dy96IeGM77aA==
 
-"@sensebox/sketch-templater@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@sensebox/sketch-templater/-/sketch-templater-1.3.0.tgz#ed17005eead6ab746d1439ee20133af938c34175"
-  integrity sha512-F+d5CLO/F8ptogX9u/DIB5Y3V+3Ag82aw/Doj5BCzURGEv4b0fHuUThBTFG4ewDPAQhud8KcjwbucM05aV2bSg==
+"@sensebox/sketch-templater@^1.4.0-beta.3":
+  version "1.4.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@sensebox/sketch-templater/-/sketch-templater-1.4.0-beta.3.tgz#ea065c3e1bd95312603a573296c7683cdb7c1b99"
+  integrity sha512-W93QAitK8bYYYiHgatQe8qMUwhCVXj40O6ahLi20aSnhPJsCVPUpF2h9rqf3cVD5BbJ6u4Z2WV/zV3FsYGk3Sg==
   dependencies:
     config "^1.29.2"
     dedent "^0.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,10 +19,10 @@
   resolved "https://registry.yarnpkg.com/@sensebox/osem-protos/-/osem-protos-1.1.0.tgz#a7de8bc6be867953f1309181a012063c23299e79"
   integrity sha512-H+nUVcWlT0dvIqfJnYHuX9JBcCkP1ZKGE5YTRNWPbAEdZ11h+srpQsmeI58wK5hJcdukaZAjc4Dy96IeGM77aA==
 
-"@sensebox/sketch-templater@^1.4.0-beta.3":
-  version "1.4.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@sensebox/sketch-templater/-/sketch-templater-1.4.0-beta.3.tgz#ea065c3e1bd95312603a573296c7683cdb7c1b99"
-  integrity sha512-W93QAitK8bYYYiHgatQe8qMUwhCVXj40O6ahLi20aSnhPJsCVPUpF2h9rqf3cVD5BbJ6u4Z2WV/zV3FsYGk3Sg==
+"@sensebox/sketch-templater@^1.4.0-beta.4":
+  version "1.4.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@sensebox/sketch-templater/-/sketch-templater-1.4.0-beta.4.tgz#76cd8d7faa49bde4f63a69d39c073002d881e3b1"
+  integrity sha512-iYb6P/92wsc0CL3hHVlOgT5cvPkub+wkCCcWz8ON+hWcdsyvqjhLLVsrpxj/p5H2GRwY3lZA8/55doBlTjZydw==
   dependencies:
     config "^1.29.2"
     dedent "^0.7.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The latest beta release of `@sensebox/sketch-templater` adds variables and replacements for `ssid` and `password` for senseBox MCU WiFi models.

## Description
<!--- Describe your changes in detail -->
You can post `ssid` and `password` for your wifi to the `/script` route and it will replace it inside the arduino sketch.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Now it is possible to get a full configured sketch which can be used in combination with the `compiler` used by `ardublockly for senseBox` to get a `.bin` file. This file can be copied to the new senseBox MCU in USB mode. Finally you need no installed Arduino on your computer.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been linted using `yarn run lint`.
- [x] My code does not break the tests (`yarn run test`)
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
