### PR TITLE
Set lastMeasurementAt on single measurement upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## v6
+- Use @sensebox/opensensemap-api-models v0.0.11
+- Support for `hackAIR` devices
+- Support for `bbox` query parameter on `/boxes`. Closes #174
+
 ## v5
 - Allow users to delete their box images by sending `deleteImage: true`
 - Change Forbidden Response for invalid JWT authorization

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,7 +10,7 @@
     "Norwin Roosen"
   ],
   "dependencies": {
-    "@sensebox/opensensemap-api-models": "^0.0.11-beta.2",
+    "@sensebox/opensensemap-api-models": "^0.0.11",
     "@turf/area": "^4.6.0",
     "@turf/bbox": "^4.6.0",
     "@turf/centroid": "^4.6.1",

--- a/packages/models/CHANGELOG.md
+++ b/packages/models/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## v0.0.11
+- **BREAKING CHANGE**: `/boxes` sensor does not contain `lastMeasurement` anymore
+- introduce `minimal` parameter to reduce payload on `/boxes` #164
+- introduce `lastMeasurementAt` in box schema and update field every time new measurement is stored to avoid additional databse lookup. Fixes #148
+- Uploading a single measurement with a specified time. Fixes #169
+- Update @sensebox/node-sketch-templater to 1.3.0
+- Add new LoRa model (`homeV2Lora`). Fixes #165
+- add `bbox` parameter to `/boxes` route
+- add `hackAir` decoding handler
+
 ## v0.0.11-beta.2
 
 ## v0.0.11-beta.1

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sensebox/opensensemap-api-models",
   "description": "openSenseMap data models and database connection",
-  "version": "0.0.11-beta.2",
+  "version": "0.0.11",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {

--- a/packages/models/src/box/box.js
+++ b/packages/models/src/box/box.js
@@ -469,6 +469,7 @@ boxSchema.methods.saveMeasurement = function saveMeasurement (measurement) {
       // only update lastMeasurement, if timestamp is actually the newest.
       if (!sensor.lastMeasurement || m.createdAt.valueOf() > sensor.lastMeasurement.createdAt.getTime()) {
         sensor.lastMeasurement = m;
+        box.lastMeasurementAt = m.createdAt;
 
         return box.save();
       }
@@ -589,6 +590,7 @@ boxSchema.methods.saveMeasurementsArray = function saveMeasurementsArray (measur
 
           // compare send measurements with actual lastMeasurements if each sensor
           if (
+            !box.sensors[i].lastMeasurement ||
             box.sensors[i].lastMeasurement === undefined ||
             box.sensors[i].lastMeasurement !== undefined &&
             lastMeasurements[box.sensors[i]._id].createdAt.isAfter(box.sensors[i].lastMeasurement.createdAt)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
`Custom` senseBox models are marked as `old` though they have live data.

## Description
<!--- Describe your changes in detail -->
The box property `lastMeasurementAt` is also set on uploading a single measurement for a sensor.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a fix for #177

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been linted using `yarn run lint`.
- [x] My code does not break the tests (`yarn run test`)
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
