### PR TITLE
GPS Sketch Generation

### DIFF
--- a/packages/api/lib/controllers/boxesController.js
+++ b/packages/api/lib/controllers/boxesController.js
@@ -414,7 +414,7 @@ const getSketch = async function getSketch (req, res, next) {
   res.header('Content-Type', 'text/plain; charset=utf-8');
   try {
     const box = await Box.findBoxById(req._userParams.boxId, { populate: false, lean: false });
-    res.send(box.getSketch({ serialPort: req._userParams.serialPort, ssid: req._userParams.ssid, password: req._userParams.password }));
+    res.send(box.getSketch({ serialPort: req._userParams.serialPort, ssid: req._userParams.ssid, password: req._userParams.password, postingInterval: req._userParams.postingInterval }));
   } catch (err) {
     handleError(err, next);
   }

--- a/packages/api/lib/controllers/boxesController.js
+++ b/packages/api/lib/controllers/boxesController.js
@@ -461,7 +461,8 @@ module.exports = {
       { predef: 'boxId', required: true },
       { name: 'serialPort', dataType: 'String', allowedValues: ['Serial1', 'Serial2'] },
       { name: 'ssid', dataType: 'StringWithEmpty' },
-      { name: 'password', dataType: 'StringWithEmpty' }
+      { name: 'password', dataType: 'StringWithEmpty' },
+      { name: 'postingInterval', dataType: 'Number', defaultValue: 60000 }
     ]),
     checkPrivilege,
     getSketch

--- a/packages/api/lib/controllers/boxesController.js
+++ b/packages/api/lib/controllers/boxesController.js
@@ -407,6 +407,11 @@ const postNewBox = async function postNewBox (req, res, next) {
  * @api {get} /boxes/:senseBoxId/script Download the Arduino script for your senseBox
  * @apiName getSketch
  * @apiGroup Boxes
+ * @apiParam (RequestBody) {String} [boxId] the id of the senseBox 
+ * @apiParam (RequestBody) {String="Serial1","Serial2"} [serialPort] the serialPort of the particulate matter sensor 
+ * @apiParam (RequestBody) {String} [ssid] the ssid of your wifi 
+ * @apiParam (RequestBody) {String} [password] the password of your wifi
+ * @apiParam (RequestBody) {Number} [postingInterval] the interval in ms your senseBox should send measurements
  * @apiUse JWTokenAuth
  * @apiUse BoxIdParam
  */

--- a/packages/models/src/box/box.js
+++ b/packages/models/src/box/box.js
@@ -800,13 +800,14 @@ boxSchema.methods.updateSensors = function updateSensors (sensors) {
   }
 };
 
-boxSchema.methods.getSketch = function getSketch ({ encoding, serialPort, ssid, password } = {}) {
+boxSchema.methods.getSketch = function getSketch ({ encoding, serialPort, ssid, password, postingInterval } = {}) {
   if (serialPort) {
     this.serialPort = serialPort;
   }
 
   this.ssid = ssid;
   this.password = password;
+  this.postingInterval = postingInterval;
 
   return templateSketcher.generateSketch(this, { encoding });
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds option to include `postingInterval` for GPS enabled sketches

## Description
<!--- Describe your changes in detail -->
Adding `postingInterval` will allow users to modify the time rate their box should send measurements. This is especially useful for mobile senseBoxes. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In preparation for https://github.com/sensebox/node-sketch-templater/pull/17 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
TBD

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been linted using `yarn run lint`.
- [x] My code does not break the tests (`yarn run test`)
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
