### PR TITLE
add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,8 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"
+    target_branch: "development"
+    default_reviewers:
+    - "ubergesundheit"


### PR DESCRIPTION
Adds a configuration file for dependabot

-> changes default branch to be `development`
-> automatically requests review from me