### PR TITLE
Add route for retrieving the latest measurement of a single sensor

### DIFF
--- a/packages/api/lib/helpers/userParamHelpers.js
+++ b/packages/api/lib/helpers/userParamHelpers.js
@@ -54,6 +54,7 @@ const stringParser = function stringParser (s) {
   try {
     return s ? s.toString().trim() : s;
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.log('toString', err);
   }
 };
@@ -189,6 +190,7 @@ const castParam = function castParam (param, paramDataType, dataTypeIsArray) {
     for (let i = 0, len = param.length; i < len; i++) {
       // also use parser for mapping
       if (!param[i]) {
+        // eslint-disable-next-line no-console
         console.log('PARAM NOT DEFINED', param, i);
       }
       param[i] = parser(param[i]);

--- a/packages/api/lib/routes.js
+++ b/packages/api/lib/routes.js
@@ -80,6 +80,7 @@ const routes = {
     { path: `${boxesPath}/data`, method: 'get', handler: measurementsController.getDataMulti, reference: 'api-Measurements-getDataMulti' },
     { path: `${boxesPath}/:boxId`, method: 'get', handler: boxesController.getBox, reference: 'api-Boxes-getBox' },
     { path: `${boxesPath}/:boxId/sensors`, method: 'get', handler: measurementsController.getLatestMeasurements, reference: 'api-Measurements-getLatestMeasurements' },
+    { path: `${boxesPath}/:boxId/sensors/:sensorId`, method: 'get', handler: measurementsController.getLatestMeasurements, reference: 'api-Measurements-getLatestMeasurementOfSensor' },
     { path: `${boxesPath}/:boxId/data/:sensorId`, method: 'get', handler: measurementsController.getData, reference: 'api-Measurements-getData' },
     { path: `${boxesPath}/:boxId/locations`, method: 'get', handler: boxesController.getBoxLocations, reference: 'api-Measurements-getLocations' },
     { path: `${boxesPath}/data`, method: 'post', handler: measurementsController.getDataMulti, reference: 'api-Measurements-getDataMulti' },

--- a/tests/data/boxSensorsSchema.js
+++ b/tests/data/boxSensorsSchema.js
@@ -1,0 +1,56 @@
+'use strict';
+
+module.exports = {
+  '$schema': 'http://json-schema.org/draft-04/schema#',
+  'type': 'object',
+  'properties': {
+    '_id': {
+      'type': 'string'
+    },
+    'sensors': {
+      'type': 'array',
+      'items': {
+        'type': 'object',
+        'properties': {
+          'title': {
+            'type': 'string'
+          },
+          'unit': {
+            'type': 'string'
+          },
+          'sensorType': {
+            'type': 'string'
+          },
+          '_id': {
+            'type': 'string'
+          },
+          'lastMeasurement': {
+            'type': 'object',
+            'properties': {
+              'value': {
+                'type': 'string'
+              },
+              'createdAt': {
+                'type': 'string'
+              }
+            },
+            'required': [
+              'value',
+              'createdAt'
+            ]
+          }
+        },
+        'required': [
+          'title',
+          'unit',
+          'sensorType',
+          '_id'
+        ]
+      }
+    },
+  },
+  'required': [
+    '_id',
+    'sensors'
+  ]
+};

--- a/tests/data/sensorSchema.js
+++ b/tests/data/sensorSchema.js
@@ -1,0 +1,41 @@
+'use strict';
+
+module.exports = {
+  '$schema': 'http://json-schema.org/draft-04/schema#',
+  'type': 'object',
+  'properties': {
+    'title': {
+      'type': 'string'
+    },
+    'unit': {
+      'type': 'string'
+    },
+    'sensorType': {
+      'type': 'string'
+    },
+    '_id': {
+      'type': 'string'
+    },
+    'lastMeasurement': {
+      'type': 'object',
+      'properties': {
+        'value': {
+          'type': 'string'
+        },
+        'createdAt': {
+          'type': 'string'
+        }
+      },
+      'required': [
+        'value',
+        'createdAt'
+      ]
+    }
+  },
+  'required': [
+    'title',
+    'unit',
+    'sensorType',
+    '_id'
+  ]
+};

--- a/tests/tests/007-download-data-test.js
+++ b/tests/tests/007-download-data-test.js
@@ -10,7 +10,9 @@ const BASE_URL = process.env.OSEM_TEST_BASE_URL,
   findAllSchema = require('../data/findAllSchema'),
   findAllSchemaBoxes = require('../data/findAllSchemaBoxes'),
   measurementsSchema = require('../data/measurementsSchema'),
-  getUserBoxesSchema = require('../data/getUserBoxesSchema');
+  getUserBoxesSchema = require('../data/getUserBoxesSchema'),
+  boxSensorsSchema = require('../data/boxSensorsSchema'),
+  sensorSchema = require('../data/sensorSchema');
 
 describe('downloading data', function () {
   let jwt;
@@ -172,6 +174,32 @@ describe('downloading data', function () {
           expect(response.body.length).to.be.equal(1);
           expect(response).to.have.header('content-type', 'application/json; charset=utf-8');
           expect(response).to.have.schema(findAllSchema);
+
+          return chakram.wait();
+        });
+    });
+
+  });
+
+  describe('/boxes/:boxid/sensors', function () {
+
+    it('should return the sensors of a box for /boxes/:boxid/sensors GET', function () {
+      return chakram.get(`${BASE_URL}/boxes/${boxIds[0]}/sensors`)
+        .then(function (response) {
+          expect(response).to.have.status(200);
+          expect(response).to.have.header('content-type', 'application/json; charset=utf-8');
+          expect(response).to.have.schema(boxSensorsSchema);
+
+          return chakram.wait();
+        });
+    });
+
+    it('should return a single sensor of a box for /boxes/:boxid/sensors/:sensorId GET', function () {
+      return chakram.get(`${BASE_URL}/boxes/${boxes[0]._id}/sensors/${boxes[0].sensors[0]._id}`)
+        .then(function (response) {
+          expect(response).to.have.status(200);
+          expect(response).to.have.header('content-type', 'application/json; charset=utf-8');
+          expect(response).to.have.schema(sensorSchema);
 
           return chakram.wait();
         });


### PR DESCRIPTION
This PR adds a new route for retrieving the latest measurement of a single sensor.

Example:
```
GET /boxes/:boxId/sensors/:sensorId
{"title":"UV-Intensität","unit":"μW/cm²","sensorType":"VEML6070","icon":"osem-brightness","_id":"5f3d7e319b0b56c8bff36547","lastMeasurement":{"value":"4","createdAt":"2020-08-19T19:33:29.395Z"}}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been linted using `yarn run lint`.
- [x] My code does not break the tests (`yarn run test`)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
