### PR TITLE
Use node v14

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Make sure you have the following tools installed:
 
 - Docker
 - Docker Compose
-- Node.Js v8
+- Node.Js v14
 - Yarn package manager
 
 Fork, then clone the repo:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine as build
+FROM node:14-alpine as build
 
 ENV NODE_ENV=production
 
@@ -23,7 +23,7 @@ RUN yarn create-version-file \
   && rm -rf .git .scripts
 
 # Final stage
-FROM node:12-alpine
+FROM node:14-alpine
 
 ENV NODE_ENV=production
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You'll find that the repostiory uses yarn workspaces to separate the [API](packa
 Configuration of both the api and the models is done using mechanisms provided by [lorenwest/node-config](https://github.com/lorenwest/node-config). You can find an annotated example configuration with all keys in [`config/config.example.json`](config/config.example.json).
 
 ## Development
-- Have [Node.js] v12, [yarn](https://yarnpkg.com/), [Docker](https://docs.docker.com/engine/installation/) and [docker-compose](https://docs.docker.com/compose/install/) installed
+- Have [Node.js] v14, [yarn](https://yarnpkg.com/), [Docker](https://docs.docker.com/engine/installation/) and [docker-compose](https://docs.docker.com/compose/install/) installed
 - Start your development database (`docker-compose up -d db`)
 - Create branch for your feature (`git checkout my-awesome-feature`)
 - Run `yarn install`

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -19,7 +19,7 @@
     "@turf/hex-grid": "^6.0.2",
     "@turf/square-grid": "^6.0.2",
     "@turf/triangle-grid": "^6.0.1",
-    "apicache": "^1.4.0",
+    "apicache": "1.5.2",
     "bunyan": "^1.8.14",
     "config": "^3.3.3",
     "csv-stringify": "^5.6.0",

--- a/tests/tests-Dockerfile
+++ b/tests/tests-Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:14-alpine
 
 # YARN_PRODUCTION=false is a workaround for https://github.com/yarnpkg/yarn/issues/4557
 ENV NODE_ENV=production \

--- a/yarn.lock
+++ b/yarn.lock
@@ -350,10 +350,10 @@ anymatch@~3.1.1:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-apicache@^1.4.0:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/apicache/-/apicache-1.5.3.tgz#8977b358bf7d579d55fe3d183c907ae5dbcfb357"
-  integrity sha512-n1h39Bt7tMiJMV0u0tFlhigig8Uo/wJmKoj6WE/OwvZ+WbFchn7jnXleotZOzZTUBtr0Tg9iJshHnJDAGQbAEQ==
+apicache@1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/apicache/-/apicache-1.5.2.tgz#2cb0697d9b1b612b505b1a44face66d48b1d1404"
+  integrity sha512-jO8ie/Zqmr3MxLQSVNsHiQo5R1tbbP1TnpI6xOnRJv9wUOSP+YnZkULWmdo3fE7PHBSxIQzgIsEHGa6H5hKH9Q==
 
 aproba@^1.0.3:
   version "1.2.0"


### PR DESCRIPTION
This PR bumps the used node version to 14. Package `apicache` added a `node < 13` in `1.5.3`. Thus the downgrade.