### PR TITLE
(api) add parameters to search for boxes with a name

### DIFF
--- a/packages/api/lib/controllers/boxesController.js
+++ b/packages/api/lib/controllers/boxesController.js
@@ -577,7 +577,7 @@ module.exports = {
   getBoxes: [
     retrieveParameters([
       { name: 'name', dataType: 'String' },
-      { name: 'limit', dataType: 'Number', defaultValue: 5, min: 1, max: 20},
+      { name: 'limit', dataType: 'Number', defaultValue: 5, min: 1, max: 20 },
       { name: 'exposure', allowedValues: Box.BOX_VALID_EXPOSURES, dataType: ['String'] },
       { name: 'model', dataType: ['StringWithEmpty'] },
       { name: 'grouptag', dataType: ['StringWithEmpty'] },

--- a/packages/api/lib/controllers/boxesController.js
+++ b/packages/api/lib/controllers/boxesController.js
@@ -192,6 +192,8 @@ const geoJsonStringifyReplacer = function geoJsonStringifyReplacer (key, box) {
  * @apiDescription With the optional `date` and `phenomenon` parameters you can find senseBoxes that have submitted data around that time, +/- 4 hours, or specify two dates separated by a comma.
  * @apiName getBoxes
  * @apiGroup Boxes
+ * @apiParam {String} [name] Search string to find boxes by name, if specified all other parameters are ignored.
+ * @apiParam {Number} [limit=5] Limit the search results.
  * @apiParam {RFC3339Date} [date] One or two RFC 3339 timestamps at which boxes should provide measurements. Use in combination with `phenomenon`.
  * @apiParam {String} [phenomenon] A sensor phenomenon (determined by sensor name) such as temperature, humidity or UV intensity. Use in combination with `date`.
  * @apiParam {String=json,geojson} [format=json] the format the sensor data is returned in.
@@ -221,18 +223,25 @@ const getBoxes = async function getBoxes (req, res, next) {
 
   try {
     let stream;
-    if (req._userParams.minimal === 'true') {
-      stream = await Box.findBoxesMinimal(req._userParams);
-    } else {
-      stream = await Box.findBoxesLastMeasurements(req._userParams);
-    }
 
-    if (req._userParams.classify === 'true') {
-      stream = stream
-        .pipe(new classifyTransformer())
-        .on('error', function (err) {
-          res.end(`Error: ${err.message}`);
-        });
+    // Search boxes by name
+    // Directly return results and do nothing else
+    if (req._userParams.name) {
+      stream = await Box.findBoxes(req._userParams);
+    } else {
+      if (req._userParams.minimal === 'true') {
+        stream = await Box.findBoxesMinimal(req._userParams);
+      } else {
+        stream = await Box.findBoxesLastMeasurements(req._userParams);
+      }
+
+      if (req._userParams.classify === 'true') {
+        stream = stream
+          .pipe(new classifyTransformer())
+          .on('error', function (err) {
+            res.end(`Error: ${err.message}`);
+          });
+      }
     }
 
     stream
@@ -567,6 +576,8 @@ module.exports = {
   ],
   getBoxes: [
     retrieveParameters([
+      { name: 'name', dataType: 'String' },
+      { name: 'limit', dataType: 'Number', defaultValue: 5, min: 1, max: 20},
       { name: 'exposure', allowedValues: Box.BOX_VALID_EXPOSURES, dataType: ['String'] },
       { name: 'model', dataType: ['StringWithEmpty'] },
       { name: 'grouptag', dataType: ['StringWithEmpty'] },

--- a/packages/models/src/box/box.js
+++ b/packages/models/src/box/box.js
@@ -984,7 +984,8 @@ boxSchema.statics.findBoxes = function findBoxes (opts = {}) {
   };
   const projection = {
     _id: 1,
-    name: 1
+    name: 1,
+    currentLocation: 1
   };
 
   return Promise.resolve(this.find(filter, projection).limit(limit)

--- a/packages/models/src/box/box.js
+++ b/packages/models/src/box/box.js
@@ -976,6 +976,19 @@ const buildFindBoxesQuery = function buildFindBoxesQuery (opts = {}) {
   return query;
 };
 
+// return boxes that match the name paramter
+boxSchema.statics.findBoxes = function findBoxes (opts = {}) {
+  const { name, limit } = opts;
+  const filter = {
+    name: {'$regex': name, '$options': 'i'}
+  };
+  const projection = {
+    _id: 1,
+    name: 1
+  }
+  return Promise.resolve(this.find(filter, projection).limit(limit).cursor({ lean: true }));
+}
+
 // returns a minimal subset of the box documents for speed
 boxSchema.statics.findBoxesMinimal = function findBoxesMinimal (opts = {}) {
   const query = buildFindBoxesQuery(opts);

--- a/packages/models/src/box/box.js
+++ b/packages/models/src/box/box.js
@@ -980,14 +980,16 @@ const buildFindBoxesQuery = function buildFindBoxesQuery (opts = {}) {
 boxSchema.statics.findBoxes = function findBoxes (opts = {}) {
   const { name, limit } = opts;
   const filter = {
-    name: {'$regex': name, '$options': 'i'}
+    name: { '$regex': name, '$options': 'i' }
   };
   const projection = {
     _id: 1,
     name: 1
-  }
-  return Promise.resolve(this.find(filter, projection).limit(limit).cursor({ lean: true }));
-}
+  };
+
+  return Promise.resolve(this.find(filter, projection).limit(limit)
+    .cursor({ lean: true }));
+};
 
 // returns a minimal subset of the box documents for speed
 boxSchema.statics.findBoxesMinimal = function findBoxesMinimal (opts = {}) {

--- a/tests/tests/005-create-boxes-test.js
+++ b/tests/tests/005-create-boxes-test.js
@@ -234,6 +234,61 @@ describe('openSenseMap API Routes: /boxes', function () {
       });
   });
 
+  it('should serach for boxes with a specific name', function () {
+    return chakram.get(`${BASE_URL}/boxes?name=sensebox`)
+      .then(function (response) {
+        expect(response).to.have.status(200);
+        expect(response).to.have.header('content-type', 'application/json; charset=utf-8');
+        expect(response.body.length).to.be.equal(3);
+
+        return chakram.wait();
+      });
+  });
+
+  it('should serach for boxes with a specific name and limit the results', function () {
+    return chakram.get(`${BASE_URL}/boxes?name=sensebox&limit=2`)
+      .then(function (response) {
+        expect(response).to.have.status(200);
+        expect(response).to.have.header('content-type', 'application/json; charset=utf-8');
+
+        expect(response.body.length).to.be.equal(2);
+
+        return chakram.wait();
+      });
+  });
+
+  it('should deny searching for a name if limit is greater than max value', function () {
+    return chakram.get(`${BASE_URL}/boxes?name=sensebox&limit=21`)
+      .then(function (response) {
+        expect(response).to.have.status(422);
+        expect(response).to.have.header('content-type', 'application/json; charset=utf-8');
+        expect(response).json({ code: 'UnprocessableEntity', message: 'Illegal value for parameter limit. Supplied value 21 is outside of allowed range (> 20)' });
+
+        return chakram.wait();
+      });
+  });
+
+  it('should deny searching for a name if limit is lower than min value', function () {
+    return chakram.get(`${BASE_URL}/boxes?name=sensebox&limit=0`)
+      .then(function (response) {
+        expect(response).to.have.status(422);
+        expect(response).to.have.header('content-type', 'application/json; charset=utf-8');
+        expect(response).json({ code: 'UnprocessableEntity', message: 'Illegal value for parameter limit. Supplied value 0 is outside of allowed range (< 1)' });
+
+        return chakram.wait();
+      });
+  });
+
+  it('should return empty array if there are no results', function () {
+    return chakram.get(`${BASE_URL}/boxes?name=asdf&limit=5`)
+      .then(function (response) {
+        expect(response).to.have.status(200);
+        expect(response).to.have.header('content-type', 'application/json; charset=utf-8');
+        expect(response).to.comprise.of.json([]);
+
+        return chakram.wait();
+      });
+  });
 
   it('should allow to create new sensors via PUT', function () {
     return chakram.put(`${BASE_URL}/boxes/${custombox_id}`, { 'sensors': [{ 'title': 'PM10', 'unit': 'µg/m³', 'sensorType': 'SDS 011', 'edited': 'true', 'new': 'true' }, { 'title': 'PM2.5', 'unit': 'µg/m³', 'sensorType': 'SDS 011', 'edited': 'true', 'new': 'true' }] }, { headers: { 'Authorization': `Bearer ${jwt2}` } })


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR introduces two new parameters for `/boxes` to query and filter boxes by name. It should be used
to search for boxes in the frontend.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Right now the search for boxes in implemented in the frontend. This should be moved to the backend.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested it locally and wrote some tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been linted using `yarn run lint`.
- [x] My code does not break the tests (`yarn run test`)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
