### PR TITLE
Update grouptag in management routes

### DIFF
--- a/packages/api/lib/controllers/managementController.js
+++ b/packages/api/lib/controllers/managementController.js
@@ -241,7 +241,7 @@ module.exports = {
     retrieveParameters([
       { predef: 'boxId', required: true },
       { name: 'name' },
-      { name: 'grouptag', dataType: 'StringWithEmpty' },
+      { name: 'grouptag', dataType: ['String'] },
       { name: 'description', dataType: 'StringWithEmpty' },
       { name: 'weblink', dataType: 'StringWithEmpty' },
       { name: 'image', dataType: 'base64Image' },


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Change parameter `grouptag` to `['String']` within the management routes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `grouptag` in the `box` schema changed from `String` to `['String']` (array of strings). 
We forgot to update the parameter inside our management routes that are used by our admin tool.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been linted using `yarn run lint`.
- [x] My code does not break the tests (`yarn run test`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
