### PR TITLE
Remove old mailer and add Redis based queue system

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,4 +16,3 @@ services:
       - ./.scripts/mongodb/osem_admin.sh:/docker-entrypoint-initdb.d/osem_admin.sh
       # - ./.scripts/mongodb/osem_seed_boxes.sh:/docker-entrypoint-initdb.d/osem_seed_boxes.sh
       # - ./.scripts/mongodb/osem_seed_measurements.sh:/docker-entrypoint-initdb.d/osem_seed_measurements.sh
-      

--- a/packages/api/lib/controllers/usersController.js
+++ b/packages/api/lib/controllers/usersController.js
@@ -2,10 +2,19 @@
 
 const { User } = require('@sensebox/opensensemap-api-models'),
   { InternalServerError, ForbiddenError } = require('restify-errors'),
-  { checkContentType, redactEmail, clearCache, postToMattermost } = require('../helpers/apiUtils'),
+  {
+    checkContentType,
+    redactEmail,
+    clearCache,
+    postToMattermost,
+  } = require('../helpers/apiUtils'),
   { retrieveParameters } = require('../helpers/userParamHelpers'),
   handleError = require('../helpers/errorHandler'),
-  { createToken, refreshJwt, invalidateToken } = require('../helpers/jwtHelpers');
+  {
+    createToken,
+    refreshJwt,
+    invalidateToken,
+  } = require('../helpers/jwtHelpers');
 
 /**
  * define for nested user parameter for box creation request
@@ -47,16 +56,27 @@ const registerUser = async function registerUser (req, res) {
   const { email, password, language, name } = req._userParams;
 
   try {
-    const newUser = await new User({ name, email, password, language })
-      .save();
-    postToMattermost(`New User: ${newUser.name} (${redactEmail(newUser.email)})`);
+    const newUser = await new User({ name, email, password, language }).save();
+    postToMattermost(
+      `New User: ${newUser.name} (${redactEmail(newUser.email)})`
+    );
 
     try {
       const { token, refreshToken } = await createToken(newUser);
 
-      return res.send(201, { code: 'Created', message: 'Successfully registered new user', data: { user: newUser }, token, refreshToken });
+      return res.send(201, {
+        code: 'Created',
+        message: 'Successfully registered new user',
+        data: { user: newUser },
+        token,
+        refreshToken,
+      });
     } catch (err) {
-      return Promise.reject(new InternalServerError(`User successfully created but unable to create jwt token: ${err.message}`));
+      return Promise.reject(
+        new InternalServerError(
+          `User successfully created but unable to create jwt token: ${err.message}`
+        )
+      );
     }
   } catch (err) {
     return handleError(err);
@@ -82,18 +102,26 @@ const signIn = async function signIn (req, res) {
 
   try {
     // lowercase for email
-    const user = await User
-      .findOne({ $or: [{ email: emailOrName.toLowerCase() }, { name: emailOrName }] })
-      .exec();
+    const user = await User.findOne({
+      $or: [{ email: emailOrName.toLowerCase() }, { name: emailOrName }],
+    }).exec();
 
     if (!user) {
-      return Promise.reject(new ForbiddenError('User and or password not valid!'));
+      return Promise.reject(
+        new ForbiddenError('User and or password not valid!')
+      );
     }
 
     if (await user.checkPassword(password)) {
       const { token, refreshToken } = await createToken(user);
 
-      return res.send(200, { code: 'Authorized', message: 'Successfully signed in', data: { user }, token, refreshToken });
+      return res.send(200, {
+        code: 'Authorized',
+        message: 'Successfully signed in',
+        data: { user },
+        token,
+        refreshToken,
+      });
     }
   } catch (err) {
     if (err.name === 'ModelError' && err.message === 'Password incorrect') {
@@ -119,8 +147,16 @@ const signIn = async function signIn (req, res) {
  */
 const refreshJWT = async function refreshJWT (req, res) {
   try {
-    const { token, refreshToken, user } = await refreshJwt(req._userParams.token);
-    res.send(200, { code: 'Authorized', message: 'Successfully refreshed auth', data: { user }, token, refreshToken });
+    const { token, refreshToken, user } = await refreshJwt(
+      req._userParams.token
+    );
+    res.send(200, {
+      code: 'Authorized',
+      message: 'Successfully refreshed auth',
+      data: { user },
+      token,
+      refreshToken,
+    });
   } catch (err) {
     return handleError(err);
   }
@@ -174,7 +210,11 @@ const requestResetPassword = async function requestResetPassword (req, res) {
 const resetPassword = async function resetPassword (req, res) {
   try {
     await User.resetPassword(req._userParams);
-    res.send(200, { code: 'Ok', message: 'Password successfully changed. You can now login with your new password' });
+    res.send(200, {
+      code: 'Ok',
+      message:
+        'Password successfully changed. You can now login with your new password',
+    });
   } catch (err) {
     return handleError(err);
   }
@@ -193,7 +233,10 @@ const resetPassword = async function resetPassword (req, res) {
 const confirmEmailAddress = async function confirmEmailAddress (req, res) {
   try {
     await User.confirmEmail(req._userParams);
-    res.send(200, { code: 'Ok', message: 'E-Mail successfully confirmed. Thank you' });
+    res.send(200, {
+      code: 'Ok',
+      message: 'E-Mail successfully confirmed. Thank you',
+    });
   } catch (err) {
     return handleError(err);
   }
@@ -211,7 +254,10 @@ const getUserBoxes = async function getUserBoxes (req, res) {
   try {
     const boxes = await req.user.getBoxes();
     const sharedBoxes = await req.user.getSharedBoxes();
-    res.send(200, { code: 'Ok', data: { boxes: boxes, sharedBoxes: sharedBoxes } });
+    res.send(200, {
+      code: 'Ok',
+      data: { boxes: boxes, sharedBoxes: sharedBoxes },
+    });
   } catch (err) {
     return handleError(err);
   }
@@ -242,15 +288,23 @@ const getUser = async function getUser (req, res) {
  */
 const updateUser = async function updateUser (req, res) {
   try {
-    const { updated, signOut, messages, updatedUser } = await req.user.updateUser(req._userParams);
+    const { updated, signOut, messages, updatedUser } =
+      await req.user.updateUser(req._userParams);
     if (updated === false) {
-      return res.send(200, { code: 'Ok', message: 'No changed properties supplied. User remains unchanged.' });
+      return res.send(200, {
+        code: 'Ok',
+        message: 'No changed properties supplied. User remains unchanged.',
+      });
     }
 
     if (signOut === true) {
       invalidateToken(req);
     }
-    res.send(200, { code: 'Ok', message: `User successfully saved.${messages.join('.')}`, data: { me: updatedUser } });
+    res.send(200, {
+      code: 'Ok',
+      message: `User successfully saved.${messages.join('.')}`,
+      data: { me: updatedUser },
+    });
   } catch (err) {
     return handleError(err);
   }
@@ -273,9 +327,14 @@ const deleteUser = async function deleteUser (req, res) {
     invalidateToken(req);
 
     await req.user.destroyUser();
-    res.send(200, { code: 'Ok', message: 'User and all boxes of user marked for deletion. Bye Bye!' });
+    res.send(200, {
+      code: 'Ok',
+      message: 'User and all boxes of user marked for deletion. Bye Bye!',
+    });
     clearCache(['getBoxes', 'getStats']);
-    postToMattermost(`User deleted: ${req.user.name} (${redactEmail(req.user.email)})`);
+    postToMattermost(
+      `User deleted: ${req.user.name} (${redactEmail(req.user.email)})`
+    );
   } catch (err) {
     return handleError(err);
   }
@@ -290,14 +349,20 @@ const deleteUser = async function deleteUser (req, res) {
  * @apiSuccess {String} code `Ok`
  * @apiSuccess {String} message `Email confirmation has been sent to <emailaddress>`
  */
-const requestEmailConfirmation = async function requestEmailConfirmation (req, res) {
+const requestEmailConfirmation = async function requestEmailConfirmation (
+  req,
+  res
+) {
   try {
     const result = await req.user.resendEmailConfirmation();
     let usedAddress = result.email;
     if (result.unconfirmedEmail) {
       usedAddress = result.unconfirmedEmail;
     }
-    res.send(200, { code: 'Ok', message: `Email confirmation has been sent to ${usedAddress}` });
+    res.send(200, {
+      code: 'Ok',
+      message: `Email confirmation has been sent to ${usedAddress}`,
+    });
   } catch (err) {
     return handleError(err);
   }
@@ -310,9 +375,9 @@ module.exports = {
       { name: 'email', dataType: 'email', required: true },
       { predef: 'password' },
       { name: 'name', required: true, dataType: 'as-is' },
-      { name: 'language', defaultValue: 'en_US' }
+      { name: 'language', defaultValue: 'en_US' },
     ]),
-    registerUser
+    registerUser,
   ],
   signIn: [
     checkContentType,
@@ -320,23 +385,21 @@ module.exports = {
       { name: 'email', required: true },
       { predef: 'password' },
     ]),
-    signIn
+    signIn,
   ],
   signOut,
   resetPassword: [
     checkContentType,
     retrieveParameters([
       { name: 'token', required: true },
-      { predef: 'password' }
+      { predef: 'password' },
     ]),
-    resetPassword
+    resetPassword,
   ],
   requestResetPassword: [
     checkContentType,
-    retrieveParameters([
-      { name: 'email', dataType: 'email', required: true }
-    ]),
-    requestResetPassword
+    retrieveParameters([{ name: 'email', dataType: 'email', required: true }]),
+    requestResetPassword,
   ],
   confirmEmailAddress: [
     checkContentType,
@@ -344,7 +407,7 @@ module.exports = {
       { name: 'token', required: true },
       { name: 'email', dataType: 'email', required: true },
     ]),
-    confirmEmailAddress
+    confirmEmailAddress,
   ],
   requestEmailConfirmation,
   getUserBoxes,
@@ -355,23 +418,19 @@ module.exports = {
       { predef: 'password', name: 'currentPassword', required: false },
       { predef: 'password', name: 'newPassword', required: false },
       { name: 'name', dataType: 'as-is' },
-      { name: 'language' }
+      { name: 'language' },
     ]),
-    updateUser
+    updateUser,
   ],
   getUser,
   refreshJWT: [
     checkContentType,
-    retrieveParameters([
-      { name: 'token', required: true }
-    ]),
-    refreshJWT
+    retrieveParameters([{ name: 'token', required: true }]),
+    refreshJWT,
   ],
   deleteUser: [
     checkContentType,
-    retrieveParameters([
-      { predef: 'password' }
-    ]),
-    deleteUser
-  ]
+    retrieveParameters([{ predef: 'password' }]),
+    deleteUser,
+  ],
 };

--- a/packages/models/index.js
+++ b/packages/models/index.js
@@ -7,36 +7,44 @@ process.env.SUPPRESS_NO_CONFIG_WARNING = 'y';
 const config = require('config');
 
 config.util.setModuleDefaults('openSenseMap-API-models', {
-  'db': {
-    'host': 'localhost',
-    'port': 27017,
-    'user': 'admin',
-    'userpass': 'admin',
-    'authsource': 'OSeM-api',
-    'db': 'OSeM-api',
-    'mongo_uri': ''
+  db: {
+    host: 'localhost',
+    port: 27017,
+    user: 'admin',
+    userpass: 'admin',
+    authsource: 'OSeM-api',
+    db: 'OSeM-api',
+    mongo_uri: '',
   },
-  'integrations': {
-    'ca_cert': '',
-    'cert': '',
-    'key': '',
-    'mailer': {
-      'url': '',
-      'origin': ''
+  integrations: {
+    ca_cert: '',
+    cert: '',
+    key: '',
+    redis: {
+      host: '',
+      port: 6379,
+      username: '',
+      password: '',
+      db: 0
     },
-    'mqtt': {
-      'url': ''
-    }
+    mailer: {
+      url: '',
+      origin: '',
+      queue: 'mails',
+    },
+    mqtt: {
+      url: '',
+    },
   },
-  'password': {
-    'min_length': 8,
-    'salt_factor': 13
+  password: {
+    min_length: 8,
+    salt_factor: 13,
   },
-  'claims_ttl': {
-    'amount': 1,
-    'unit': 'd'
+  claims_ttl: {
+    amount: 1,
+    unit: 'd',
   },
-  'image_folder': './userimages/',
+  image_folder: './userimages/',
 });
 
 const { model: Box } = require('./src/box/box'),

--- a/packages/models/index.js
+++ b/packages/models/index.js
@@ -25,7 +25,7 @@ config.util.setModuleDefaults('openSenseMap-API-models', {
       port: 6379,
       username: '',
       password: '',
-      db: 0
+      db: 0,
     },
     mailer: {
       url: '',

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -10,6 +10,7 @@
     "@sensebox/osem-protos": "^1.1.0",
     "@sensebox/sketch-templater": "1.13.0",
     "bcrypt": "^5.1.0",
+    "bullmq": "^3.10.1",
     "config": "^3.3.6",
     "got": "^11.8.2",
     "isemail": "^3.0.0",

--- a/packages/models/src/user/mails.js
+++ b/packages/models/src/user/mails.js
@@ -3,9 +3,9 @@
 const config = require('config').get('openSenseMap-API-models.integrations'),
   log = require('../log');
 
-const noMailerConfiguredFunc = function () {
-  return Promise.resolve({ msg: 'no mailer configured' });
-};
+// const noMailerConfiguredFunc = function () {
+//   return Promise.resolve({ msg: 'no mailer configured' });
+// };
 
 const noQueueConfiguredFunc = function () {
   return Promise.resolve({ msg: 'no queue configured' });
@@ -13,12 +13,12 @@ const noQueueConfiguredFunc = function () {
 
 module.exports = {
   addToQueue: noQueueConfiguredFunc,
-  sendMail: noMailerConfiguredFunc,
+  // sendMail: noMailerConfiguredFunc,
 };
 
 if (config.has('redis') && config.has('redis.host') && config.has('redis.port') && config.has('redis.username') && config.has('redis.password') && config.has('redis.db') && config.has('mailer.queue')) {
   /* eslint-disable global-require */
-  const got = require('got');
+  // const got = require('got');
   const { Queue } = require('bullmq');
   /* eslint-enable global-require */
 
@@ -136,29 +136,6 @@ if (config.has('redis') && config.has('redis.host') && config.has('redis.port') 
     },
   };
 
-  const requestMailer = (payload) => {
-    return got
-      .post(config.get('mailer.url'), {
-        cert: config.get('cert'),
-        key: config.get('key'),
-        ca: config.get('ca_cert'),
-        json: payload,
-        ecdhCurve: 'auto',
-      })
-      .then((response) => {
-        log.info({
-          msg: 'successfully sent mails',
-          mailer_response: response.body,
-          mailer_response_code: response.statusCode,
-        });
-
-        return response;
-      })
-      .catch((err) => {
-        throw err;
-      });
-  };
-
   const requestQueue = () => {
     return new Queue(config.get('mailer.queue'), {
       connection: {
@@ -192,36 +169,6 @@ if (config.has('redis') && config.has('redis.host') && config.has('redis.port') 
       }, {
         removeOnComplete: true,
       });
-    },
-    sendMail (template, user, data) {
-      if (!(template in mailTemplates)) {
-        return Promise.reject(
-          new Error(`template ${template} not implemented`)
-        );
-      }
-
-      const {
-        payload = {},
-        attachment,
-        recipient = { address: user.email, name: user.name },
-      } = mailTemplates[template](user, data);
-
-      // add user and origin to payload
-      payload.user = user;
-      payload.origin = config.get('mailer.origin');
-
-      // complete the payload
-      const mailRequestPayload = [
-        {
-          template,
-          lang: user.language,
-          recipient,
-          payload,
-          attachment,
-        },
-      ];
-
-      return requestMailer(mailRequestPayload);
-    },
+    }
   };
 }

--- a/packages/models/src/user/user.js
+++ b/packages/models/src/user/user.js
@@ -644,7 +644,8 @@ userSchema.statics.transferOwnershipOfBox = function transferOwnershipOfBox (new
 };
 
 userSchema.methods.mail = function mail (template, data) {
-  return mails.sendMail(template, this, data);
+  // return mails.sendMail(template, this, data);
+  return mails.addToQueue(template, this, data);
 };
 
 const handleE11000 = function (error, res, next) {

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -33,8 +33,16 @@ services:
               "cert": "-----BEGIN CERTIFICATE-----\nMIIFTTCCAzWgAwIBAgIRALQEmnFXPN2DhNRd0IV9DcAwDQYJKoZIhvcNAQELBQAw\nGTEXMBUGA1UEAxMOb3BlblNlbnNlTWFwQ0EwHhcNMTgwMTI0MTM0NTUzWhcNMjgw\nMTI0MTM0NTQ4WjAYMRYwFAYDVQQDDA1tYWlsZXJfY2xpZW50MIICIjANBgkqhkiG\n9w0BAQEFAAOCAg8AMIICCgKCAgEAtRv1MmOOMnL1vqaFF1uf6XzHvUUkFoQsktRM\nQgr4Kq4TpBJdt2yrEWAfgBup20//Hb3pu1tGHnINRlrfnRbu/0Twq0iXP+zjzrn1\nTIppbQb8Hr5gci25vY8efc3ZRhYDrPyf+Z+F3U5Skr2itvBEshSiy3L53YG+JJ6o\nhPeVW3ePoBOIZvFYEGNVDsEbt3DVAjdFOfB4SypZG9UyX8xNUw7aAbjLib9CkdT2\nhEDiZ6iiKDklxZnNt1fmYQ/FGJRMd3ZTMddrGcexPSY1dQOJHrnlf+fVkahfqLD4\nRmVaL0O4cc/e/YIJQEZiblD+cUduKl0itkeXj1PEbYyngGixkJ+9+WuZvOwTqNrC\ngWU1uXrRH3UKn2XGYQauauq4AqnEgvMSev7nxdXEznzey1ugEeNSHXyyvj70KrUE\nHJ1kL4aL53YD0Xd8Y0hL88MHl3GkjkojZ68U0a/0TUSfTuv+JdP19HfZY5qVKst1\n309tlgaOiQXafAsiVBRrcieFHXxvoruQy/6pTwGRtfWbyujib+xXaTX36y08IXK0\nJb45WJDoVgPswsHYqF6E/AH0NSRZrXckfMQviUea27/lOD1M96cwslDjvOngJdUu\n1zBGLdfQ8SWcs1HqdG7iq+Iuh/UGq4aJgRTENEBrc4kjQQyZszXBJmRxAWKIgN0h\n+jEzGIsCAwEAAaOBkDCBjTAOBgNVHQ8BAf8EBAMCA7gwHQYDVR0lBBYwFAYIKwYB\nBQUHAwEGCCsGAQUFBwMCMB0GA1UdDgQWBBSZeu84Gf/RkVYG9XQYJZEsl3xjUTAf\nBgNVHSMEGDAWgBSZeu84Gf/RkVYG9XQYJZEsl3xjUTAcBgNVHREEFTATggZtYWls\nZXKCCWxvY2FsaG9zdDANBgkqhkiG9w0BAQsFAAOCAgEAKh+FD9v6fuHsl9ZGMP6H\nOI2of3PJRLTEMdp2rKJ1V9ULmr7sCO3fz7vUWdyKMuJXmtt6RKWwZMQfL26fsM+l\nz18wWoNly5OhhrSf6gJF2zEEr+X6emTn/RPHejc6eQKFqrdypwi890PSmhUZShz8\nCHxbUqWLmlc6CYx6t3pDcQ4/ryr5kx9cPFiPovxo+7Cc8eTkRQQfiwBUnNlXiwIq\n5R9MCZR7/XjskJeV2WzqWeRAfQgvcCvAzCEyrb/I5bLYrBwQFnATxhPvfDjZ2E+E\nK6sE/MqEXzU1gQM/zaCzpd1pXMq7PF+NkEsHuOTdZ0CvM31LD+RwxUwuETTCFuj5\n9bfhq0CTUs3Cdot9kQ+jASWMGhAhMYolhjnd58rSF4DCG9rdCl877lC1S/oNpoUU\nSN6g7X8P7HgynQZTOjUadXNbsS92KubyjE0kS1krV6yh3JH+izfgdI+ABpcHzOAB\n2fE+vRfjVbM3qeE5t4HfD8FwZKhw+PUqrDr8qKQyRX1HPpd7wcF/9bd1mMsUkAdg\nVhnkGh9AP2jDDC9xvP/LbslU+UCRXoA5hW5suey+L2cF516iR55UNObAk/TyGjVm\neXVP290e3TZZ5v2BzJdbf2rT5N6DpKntauljfbc7KQm3HZ/2aGn9O3FvzYuhUxGE\nnNAr/VqDx2/WivNpl2OEz18=\n-----END CERTIFICATE-----\n",
               "mailer": {
                 "url": "https://mailer:3924/",
-                "origin": "http://osem-api:8000"
+                "origin": "http://osem-api:8000",
+                "queue": "mails"
               },
+              "redis": {
+                "host": "redist-stack",
+                "port": 6379,
+                "username": "queue",
+                "password": "somepassword",
+                "db": 0
+              }
               "mqtt": {
                 "url": "mqtt-osem-integration:3925"
               }
@@ -48,130 +56,23 @@ services:
       - db
 
   mailer:
-    image: sensebox/sensebox-mailer:${SENSEBOX_MAILER_TAG:-v0.0.1}
+    image: ghcr.io/opensensemap/mailer:main
     environment:
-      SENSEBOX_MAILER_SERVER_CERT: |-
-        -----BEGIN CERTIFICATE-----
-        MIIFTTCCAzWgAwIBAgIRAI1rdthaIupxUz0b/od53eUwDQYJKoZIhvcNAQELBQAw
-        GTEXMBUGA1UEAxMOb3BlblNlbnNlTWFwQ0EwHhcNMTgwMTI0MTM0NTUzWhcNMjgw
-        MTI0MTM0NTQ4WjAYMRYwFAYDVQQDDA1tYWlsZXJfc2VydmVyMIICIjANBgkqhkiG
-        9w0BAQEFAAOCAg8AMIICCgKCAgEAtRv1MmOOMnL1vqaFF1uf6XzHvUUkFoQsktRM
-        Qgr4Kq4TpBJdt2yrEWAfgBup20//Hb3pu1tGHnINRlrfnRbu/0Twq0iXP+zjzrn1
-        TIppbQb8Hr5gci25vY8efc3ZRhYDrPyf+Z+F3U5Skr2itvBEshSiy3L53YG+JJ6o
-        hPeVW3ePoBOIZvFYEGNVDsEbt3DVAjdFOfB4SypZG9UyX8xNUw7aAbjLib9CkdT2
-        hEDiZ6iiKDklxZnNt1fmYQ/FGJRMd3ZTMddrGcexPSY1dQOJHrnlf+fVkahfqLD4
-        RmVaL0O4cc/e/YIJQEZiblD+cUduKl0itkeXj1PEbYyngGixkJ+9+WuZvOwTqNrC
-        gWU1uXrRH3UKn2XGYQauauq4AqnEgvMSev7nxdXEznzey1ugEeNSHXyyvj70KrUE
-        HJ1kL4aL53YD0Xd8Y0hL88MHl3GkjkojZ68U0a/0TUSfTuv+JdP19HfZY5qVKst1
-        309tlgaOiQXafAsiVBRrcieFHXxvoruQy/6pTwGRtfWbyujib+xXaTX36y08IXK0
-        Jb45WJDoVgPswsHYqF6E/AH0NSRZrXckfMQviUea27/lOD1M96cwslDjvOngJdUu
-        1zBGLdfQ8SWcs1HqdG7iq+Iuh/UGq4aJgRTENEBrc4kjQQyZszXBJmRxAWKIgN0h
-        +jEzGIsCAwEAAaOBkDCBjTAOBgNVHQ8BAf8EBAMCA7gwHQYDVR0lBBYwFAYIKwYB
-        BQUHAwEGCCsGAQUFBwMCMB0GA1UdDgQWBBSZeu84Gf/RkVYG9XQYJZEsl3xjUTAf
-        BgNVHSMEGDAWgBSZeu84Gf/RkVYG9XQYJZEsl3xjUTAcBgNVHREEFTATggZtYWls
-        ZXKCCWxvY2FsaG9zdDANBgkqhkiG9w0BAQsFAAOCAgEAmvXA9eXTucGaGtQdbbz3
-        uDkxGIeqE24hmFiK3gykUeQ+h3NQsM0FnKKuLjCLqMgGo1Dr8BSMDoTrlx9ellfP
-        GzAyM/0xZzaDNxYr5fjVgQuy9BFyjJIvDUAbT4df3USGW8URln3a2lop4HqOBzeN
-        9mnyNT1Ta0TCLkOgV10KVj38vP8YiJmegKiYgHqpVQ//ntjvigJYDOmwQbZQjxMn
-        4tuld6rZ4Rq/gAiHtk76UyFv3aXm0p6wT+s/WdlPkwkqftcgvtl2TnR32U9un4Pj
-        MhQlYbHEE9SJ01FuNmdeMXRf0HkOk4CGpm5WqFZVaVRtR2kHGuji1WXuWxcpnNBf
-        epHX1ZOHmJ0lKKSzbmfIS2KAOTKgr3jFBz47+AH1lDIjuef9FYhPHIOgEr/KjIjo
-        9H7JLDQmBlI6pssGWcsAsi+vOPzC01MwWfBa0c75WFFWuJcbzCGQYUn9ZF9iOePv
-        EQ1fmzPB0A8AjqNoMfzvj4OvvJF6HCoBjRzcVbMX2P0zZB+zwYadpswo11zlMN81
-        dGuDRXYAYva69gJU5+Lj71TfusSa14lkVJ2ITi12eyTkxH2uuVTqXSVQXvWgrgS/
-        RrdADwYsMqT1IJYYXlVNLFcJyRVfyGEsqA1uTImij2/Pa2miXGdpRjFqEWGGJZ5a
-        E9oQ4S8eb7hnqaXfQuJtMsg=
-        -----END CERTIFICATE-----
-      SENSEBOX_MAILER_SERVER_KEY: |-
-        -----BEGIN RSA PRIVATE KEY-----
-        MIIJKAIBAAKCAgEAtRv1MmOOMnL1vqaFF1uf6XzHvUUkFoQsktRMQgr4Kq4TpBJd
-        t2yrEWAfgBup20//Hb3pu1tGHnINRlrfnRbu/0Twq0iXP+zjzrn1TIppbQb8Hr5g
-        ci25vY8efc3ZRhYDrPyf+Z+F3U5Skr2itvBEshSiy3L53YG+JJ6ohPeVW3ePoBOI
-        ZvFYEGNVDsEbt3DVAjdFOfB4SypZG9UyX8xNUw7aAbjLib9CkdT2hEDiZ6iiKDkl
-        xZnNt1fmYQ/FGJRMd3ZTMddrGcexPSY1dQOJHrnlf+fVkahfqLD4RmVaL0O4cc/e
-        /YIJQEZiblD+cUduKl0itkeXj1PEbYyngGixkJ+9+WuZvOwTqNrCgWU1uXrRH3UK
-        n2XGYQauauq4AqnEgvMSev7nxdXEznzey1ugEeNSHXyyvj70KrUEHJ1kL4aL53YD
-        0Xd8Y0hL88MHl3GkjkojZ68U0a/0TUSfTuv+JdP19HfZY5qVKst1309tlgaOiQXa
-        fAsiVBRrcieFHXxvoruQy/6pTwGRtfWbyujib+xXaTX36y08IXK0Jb45WJDoVgPs
-        wsHYqF6E/AH0NSRZrXckfMQviUea27/lOD1M96cwslDjvOngJdUu1zBGLdfQ8SWc
-        s1HqdG7iq+Iuh/UGq4aJgRTENEBrc4kjQQyZszXBJmRxAWKIgN0h+jEzGIsCAwEA
-        AQKCAgBsqjuyYh19k5BzNcKBQ05tb5sAqy19/QwphQvETISeRxgtx39HgQIbSMtd
-        uDtwBU2S8NH+wkMOHWxtnDSzMoFv1FN60fE+P8pnzRerNxkOe7RmVd/UYi8h1296
-        GDqXXLoT3ve1dMuC/2138iRhE0SEfPE4lOHqz9/gZPnD3jFVUiVw7IdZDNHD83Wj
-        hqY0qJSF4de9bdUfdGdG1eKFrDVw8mZHxjMJkSJGEbtfmva9L2csLy3EpAXUTf9C
-        mY2us7w1qV89dn0iWLi1cel9LgPl1bAn0FhKLvZGZvhwdHtqBH30e77V6GHYmOKS
-        QjKIkU0+Sed76vS64I3pFQ2jdC2lEBmvYrdX4n8Ab/yWBi/KyouJW583KlevLbPk
-        0GsDVQiolLLl4z5gcpGCoLH8jm/soGfXWyTBbd5Ei+01Zf/yYHTtYPh2WYLFBZ4z
-        nnhbTcquOoqF44wXPRqOBKVX1amiMG4llmIne89DGlZQaP9A+4Q+o/5aTkInupwT
-        BI2JRLe/YZb/0S/wOGKGFygvM1p1I/ToCg2FOX0ZWzkRZ9Sr9RAKMX3VHImYRSID
-        szU/PSPxSAjy22u1vgO6wAAaOaO1OS4JwpKbhqVyjuvzvIwHMVfTgqyhIRsk39Ev
-        uTqHTse8v6S+fJY3RDLR1ereWJgPpzKnDPxg2F5ROXVGaDZb0QKCAQEAzJ5c3mDz
-        Ksrsf0HpmK+w95gb4pPd529BLNVv/tKBNqUkg1jsYriL7nGLVNSKFDmIyokOb/sI
-        qzDQRNg/4LanH8lhrmtmCeH05Tkz3Aj1IwF8I8/fr/57Aj0DgxFSJ3aDgys2q4ld
-        gIR3fe4hIDF0rXb8bAYqOt7rfl3qvbRSsLjQCi358fHRQeMGDjyC9FZ6POwdQFAP
-        531uXNYnnePnuXfuSgzVBp83pW3V8rW4YkpFoPhT38msVny63EAhRcoot/2X96Cd
-        jRQNq/5v8G0luBv2DEDSP/CDfTZKhkMaauf8KIACLeYYNTz2gFvDfa5TroqAe5De
-        HZHfqh94wyBV9wKCAQEA4pZTGWk1S0WQz01AlMvRXiM7H7jEAmddRgrpQ2w7g+Ss
-        kJesYzREZ7j/kIpK3ACuQXjW/Tjlnpkp206ocCIoIwExOVG4vsewDEGaYqOvllro
-        +GW7O4DhwgeUWAao/Ge1T/gu+8z/VM9N88udbc0xq8P0jn6xial9rLkhll5rZDS7
-        iIz1mFAzrADU5c7TvElXs86KX+T6+/sE2nNwsImaZHC1oclIHl9WnJy/qCPYFS04
-        Y6q9vg+vOlzRc6KgmOp/5Jex2oQsXKx45v0O8+mfLlyT6CBw4rWb0ksHC3aM8zCr
-        cGmgbzqVYYIewnZ//yRm98Mty8p/m3p3iNNzHExdDQKCAQBfrel1HtZ1+x9tPi/x
-        8q2IiTr4zvXjg3VxdniBKoO7Pqt9M7aNTwg3viZNy3ipjmG1ezMiD7t0+UVZ+9ia
-        xi4NwggIHDZBhsQR75adXB7seIRI5qoNTKzOViNvRUkqJNPIIQvWWEw9jTOm0hPx
-        Ts7lUg8koBldH+H0XAwpGsnT0weMywTmKpIUAglR3N/LSyirlijzaryVHWTeylEK
-        FojDhB4LyEZQa2EE3QA/FtQaOeqnI5dsvIv2gSqLVP15+dbiehV2eEdTsb3W4AoN
-        3avWlFSQVDs8JMYHZbyhXX1b4hBaC8l5Fu/Y7SHC0aXu/fYpVqBPp2UFZLG2hjLc
-        4yDvAoIBACzF84mz5loHVwP/ieFdHPPzFj3AbsrizeWHRmySOHhpeUfhEKlRrKqq
-        PaW8DerHH6fETwcedREPxtuVAWeW+ENieu2OnmjkYH8rf2w6V/nn4N0kjQjHANUs
-        Vj3GoyGtBIDW08Hh0hpaFFc2RtdpkoUUZYC6vC4tla3Jrz9dTO8yFFR5NhZw0qUM
-        TQVUBzbPb0sSZvln78hW47Ce2wenSSDLvLhJY7zMrfqoZp685nfYxam8FV43DzMD
-        IEgvPHi67aan6vb44yM02XcbThcYdOHeXUOjFWtW44F8XdoABP4RAe9mj9MqylXI
-        NnfKnqQ19zrCEIySaQC6BGC/F6Hh3QkCggEBAMQxjQVI0eUBv8C+/e9HsbvnvtPz
-        BSpGdKKDvp+vfw8dP0rxCFHeDeBglTOGOB4uTUGGkU2l6HDA/pFdSOmsiXLpc/Ai
-        QX4n2sj5R5W4mCiYVuHWo/BCkEF7utcwHu3raBhnYeuUooISfe2S8A/66PF9lnO9
-        +FVODW6Q+qdHNH349AXwtgOS/neg16I5hw0PgMkcNuJl+bgXlyy+0O8N2/37ofb1
-        bvj+34qtubGRdgtSP/EF8NxYWIz3VVqVyHtPOKoAR2Aa1ilg8ixbS1KfiqZejY6u
-        TZMPvBabA8anDKtUFq7OFkzPYxMYNkL4rZGltiZMPuRRJ5RKw+yNxaLVz3M=
-        -----END RSA PRIVATE KEY-----
-      SENSEBOX_MAILER_CA_CERT: |-
-        -----BEGIN CERTIFICATE-----
-        MIIE8jCCAtqgAwIBAgIBATANBgkqhkiG9w0BAQsFADAZMRcwFQYDVQQDEw5vcGVu
-        U2Vuc2VNYXBDQTAeFw0xODAxMjQxMzQ1NDlaFw0yODAxMjQxMzQ1NDlaMBkxFzAV
-        BgNVBAMTDm9wZW5TZW5zZU1hcENBMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIIC
-        CgKCAgEAtRv1MmOOMnL1vqaFF1uf6XzHvUUkFoQsktRMQgr4Kq4TpBJdt2yrEWAf
-        gBup20//Hb3pu1tGHnINRlrfnRbu/0Twq0iXP+zjzrn1TIppbQb8Hr5gci25vY8e
-        fc3ZRhYDrPyf+Z+F3U5Skr2itvBEshSiy3L53YG+JJ6ohPeVW3ePoBOIZvFYEGNV
-        DsEbt3DVAjdFOfB4SypZG9UyX8xNUw7aAbjLib9CkdT2hEDiZ6iiKDklxZnNt1fm
-        YQ/FGJRMd3ZTMddrGcexPSY1dQOJHrnlf+fVkahfqLD4RmVaL0O4cc/e/YIJQEZi
-        blD+cUduKl0itkeXj1PEbYyngGixkJ+9+WuZvOwTqNrCgWU1uXrRH3UKn2XGYQau
-        auq4AqnEgvMSev7nxdXEznzey1ugEeNSHXyyvj70KrUEHJ1kL4aL53YD0Xd8Y0hL
-        88MHl3GkjkojZ68U0a/0TUSfTuv+JdP19HfZY5qVKst1309tlgaOiQXafAsiVBRr
-        cieFHXxvoruQy/6pTwGRtfWbyujib+xXaTX36y08IXK0Jb45WJDoVgPswsHYqF6E
-        /AH0NSRZrXckfMQviUea27/lOD1M96cwslDjvOngJdUu1zBGLdfQ8SWcs1HqdG7i
-        q+Iuh/UGq4aJgRTENEBrc4kjQQyZszXBJmRxAWKIgN0h+jEzGIsCAwEAAaNFMEMw
-        DgYDVR0PAQH/BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQAwHQYDVR0OBBYEFJl6
-        7zgZ/9GRVgb1dBglkSyXfGNRMA0GCSqGSIb3DQEBCwUAA4ICAQBYJIxwwt+/C1+6
-        yjIDzQ6wkfdDWzBj9kfV90plp4zX7rhT+M2t/en0/lN2BgK3J1fw+PWbku6A19hA
-        niZ/mBZrKki0UzzqGO1/ovh3izC2zeRL1lqwxdxj29+2waPk2vH/sy97AuY3q/5G
-        E+H96RReOJZxysIAg2UxXpvgdupnTGMrh+fuU7iGm9NYLSLuD2SaZY/ZThSPFXOh
-        b59W6gMmNKo6rN09jj994rJQfsxH2JOkqiTHfwXp3Ch4Zg80XC9RvvRk6S4dtnLe
-        pQy+Bg3YjQ+sSUIaNrvWoP8ut+9aHdfSlQi/7aYD7tYEhdTK7G++4RWZ0C31G9an
-        6Yjcg1lJDWkP+ii91danhisdCwP2xteRXzpFM/uJ/dY+xBaX/Kp12bhF8PzbgJHa
-        rsDApLlywVSrZtglSJ5eBhDbuLPEGqATWCExvlPO2R4MF1CID/+aybj5o9Zfmok4
-        U8Z1QwLZElpTh1OhkYCyIzRJ2eG1Hx6svLh6nx4ai3iumbjzWh+E4xrncdTBA6hk
-        RKF+yZKDfpFF8iwemKExthQwCSjqEGi6bYf02Gw6A226FSqdD2Tw0TghnXtT9fQ6
-        yBx1uNSDDXdCFWmPzvZIMLe335mP2RKQrcGIbAUi0WgTuqFNyCshnoWmQigP6lqK
-        C5m4Hth2wvbwzeqDD2kvRQfpipy9Cw==
-        -----END CERTIFICATE-----
-      SENSEBOX_MAILER_SMTP_SERVER: mailhog
-      SENSEBOX_MAILER_SMTP_PORT: 1025
-      SENSEBOX_MAILER_SMTP_USER: ignored
-      SENSEBOX_MAILER_SMTP_PASSWORD: ignored
-      SENSEBOX_MAILER_FROM_DOMAIN: senseboxtest
-
+      - SMTP_HOST=mailhog
+      - SMTP_PORT=1025
+      - SMTP_SECURE=false
+      - SMTP_USERNAME=ignored
+      - SMTP_PASSWORD=ignored
+      - REDIS_HOST=localhost
+      - REDIS_PORT=6379
+      - REDIS_USERNAME=worker
+      - REDIS_PASSWORD=somepassword
+      - REDIS_DB=0
+      - BULLMQ_QUEUE_NAME=mails
     depends_on:
       - mailhog
+      - redis-stack
+
   mailhog:
     image: mailhog/mailhog:v1.0.1
     ports:
@@ -204,6 +105,13 @@ services:
       - "8883:8883"
     volumes:
       - ./mosquitto:/mosquitto/config
+
+  redis-stack:
+    image: redis/redis-stack-server:latest
+    volumes:
+      - ./redis/local-redis-conf.stack:/redis-stack.conf
+    ports:
+      - 6379:6379
 
   db:
     image: mongo:${MONGO_TAG:-5}

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -26,7 +26,6 @@ services:
               "salt_factor": 1
             },
             "image_folder": "/userimages/",
-
             "integrations": {
               "ca_cert": "-----BEGIN CERTIFICATE-----\nMIIE8jCCAtqgAwIBAgIBATANBgkqhkiG9w0BAQsFADAZMRcwFQYDVQQDEw5vcGVu\nU2Vuc2VNYXBDQTAeFw0xODAxMjQxMzQ1NDlaFw0yODAxMjQxMzQ1NDlaMBkxFzAV\nBgNVBAMTDm9wZW5TZW5zZU1hcENBMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIIC\nCgKCAgEAtRv1MmOOMnL1vqaFF1uf6XzHvUUkFoQsktRMQgr4Kq4TpBJdt2yrEWAf\ngBup20//Hb3pu1tGHnINRlrfnRbu/0Twq0iXP+zjzrn1TIppbQb8Hr5gci25vY8e\nfc3ZRhYDrPyf+Z+F3U5Skr2itvBEshSiy3L53YG+JJ6ohPeVW3ePoBOIZvFYEGNV\nDsEbt3DVAjdFOfB4SypZG9UyX8xNUw7aAbjLib9CkdT2hEDiZ6iiKDklxZnNt1fm\nYQ/FGJRMd3ZTMddrGcexPSY1dQOJHrnlf+fVkahfqLD4RmVaL0O4cc/e/YIJQEZi\nblD+cUduKl0itkeXj1PEbYyngGixkJ+9+WuZvOwTqNrCgWU1uXrRH3UKn2XGYQau\nauq4AqnEgvMSev7nxdXEznzey1ugEeNSHXyyvj70KrUEHJ1kL4aL53YD0Xd8Y0hL\n88MHl3GkjkojZ68U0a/0TUSfTuv+JdP19HfZY5qVKst1309tlgaOiQXafAsiVBRr\ncieFHXxvoruQy/6pTwGRtfWbyujib+xXaTX36y08IXK0Jb45WJDoVgPswsHYqF6E\n/AH0NSRZrXckfMQviUea27/lOD1M96cwslDjvOngJdUu1zBGLdfQ8SWcs1HqdG7i\nq+Iuh/UGq4aJgRTENEBrc4kjQQyZszXBJmRxAWKIgN0h+jEzGIsCAwEAAaNFMEMw\nDgYDVR0PAQH/BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQAwHQYDVR0OBBYEFJl6\n7zgZ/9GRVgb1dBglkSyXfGNRMA0GCSqGSIb3DQEBCwUAA4ICAQBYJIxwwt+/C1+6\nyjIDzQ6wkfdDWzBj9kfV90plp4zX7rhT+M2t/en0/lN2BgK3J1fw+PWbku6A19hA\nniZ/mBZrKki0UzzqGO1/ovh3izC2zeRL1lqwxdxj29+2waPk2vH/sy97AuY3q/5G\nE+H96RReOJZxysIAg2UxXpvgdupnTGMrh+fuU7iGm9NYLSLuD2SaZY/ZThSPFXOh\nb59W6gMmNKo6rN09jj994rJQfsxH2JOkqiTHfwXp3Ch4Zg80XC9RvvRk6S4dtnLe\npQy+Bg3YjQ+sSUIaNrvWoP8ut+9aHdfSlQi/7aYD7tYEhdTK7G++4RWZ0C31G9an\n6Yjcg1lJDWkP+ii91danhisdCwP2xteRXzpFM/uJ/dY+xBaX/Kp12bhF8PzbgJHa\nrsDApLlywVSrZtglSJ5eBhDbuLPEGqATWCExvlPO2R4MF1CID/+aybj5o9Zfmok4\nU8Z1QwLZElpTh1OhkYCyIzRJ2eG1Hx6svLh6nx4ai3iumbjzWh+E4xrncdTBA6hk\nRKF+yZKDfpFF8iwemKExthQwCSjqEGi6bYf02Gw6A226FSqdD2Tw0TghnXtT9fQ6\nyBx1uNSDDXdCFWmPzvZIMLe335mP2RKQrcGIbAUi0WgTuqFNyCshnoWmQigP6lqK\nC5m4Hth2wvbwzeqDD2kvRQfpipy9Cw==\n-----END CERTIFICATE-----\n",
               "key": "-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAtRv1MmOOMnL1vqaFF1uf6XzHvUUkFoQsktRMQgr4Kq4TpBJd\nt2yrEWAfgBup20//Hb3pu1tGHnINRlrfnRbu/0Twq0iXP+zjzrn1TIppbQb8Hr5g\nci25vY8efc3ZRhYDrPyf+Z+F3U5Skr2itvBEshSiy3L53YG+JJ6ohPeVW3ePoBOI\nZvFYEGNVDsEbt3DVAjdFOfB4SypZG9UyX8xNUw7aAbjLib9CkdT2hEDiZ6iiKDkl\nxZnNt1fmYQ/FGJRMd3ZTMddrGcexPSY1dQOJHrnlf+fVkahfqLD4RmVaL0O4cc/e\n/YIJQEZiblD+cUduKl0itkeXj1PEbYyngGixkJ+9+WuZvOwTqNrCgWU1uXrRH3UK\nn2XGYQauauq4AqnEgvMSev7nxdXEznzey1ugEeNSHXyyvj70KrUEHJ1kL4aL53YD\n0Xd8Y0hL88MHl3GkjkojZ68U0a/0TUSfTuv+JdP19HfZY5qVKst1309tlgaOiQXa\nfAsiVBRrcieFHXxvoruQy/6pTwGRtfWbyujib+xXaTX36y08IXK0Jb45WJDoVgPs\nwsHYqF6E/AH0NSRZrXckfMQviUea27/lOD1M96cwslDjvOngJdUu1zBGLdfQ8SWc\ns1HqdG7iq+Iuh/UGq4aJgRTENEBrc4kjQQyZszXBJmRxAWKIgN0h+jEzGIsCAwEA\nAQKCAgBsqjuyYh19k5BzNcKBQ05tb5sAqy19/QwphQvETISeRxgtx39HgQIbSMtd\nuDtwBU2S8NH+wkMOHWxtnDSzMoFv1FN60fE+P8pnzRerNxkOe7RmVd/UYi8h1296\nGDqXXLoT3ve1dMuC/2138iRhE0SEfPE4lOHqz9/gZPnD3jFVUiVw7IdZDNHD83Wj\nhqY0qJSF4de9bdUfdGdG1eKFrDVw8mZHxjMJkSJGEbtfmva9L2csLy3EpAXUTf9C\nmY2us7w1qV89dn0iWLi1cel9LgPl1bAn0FhKLvZGZvhwdHtqBH30e77V6GHYmOKS\nQjKIkU0+Sed76vS64I3pFQ2jdC2lEBmvYrdX4n8Ab/yWBi/KyouJW583KlevLbPk\n0GsDVQiolLLl4z5gcpGCoLH8jm/soGfXWyTBbd5Ei+01Zf/yYHTtYPh2WYLFBZ4z\nnnhbTcquOoqF44wXPRqOBKVX1amiMG4llmIne89DGlZQaP9A+4Q+o/5aTkInupwT\nBI2JRLe/YZb/0S/wOGKGFygvM1p1I/ToCg2FOX0ZWzkRZ9Sr9RAKMX3VHImYRSID\nszU/PSPxSAjy22u1vgO6wAAaOaO1OS4JwpKbhqVyjuvzvIwHMVfTgqyhIRsk39Ev\nuTqHTse8v6S+fJY3RDLR1ereWJgPpzKnDPxg2F5ROXVGaDZb0QKCAQEAzJ5c3mDz\nKsrsf0HpmK+w95gb4pPd529BLNVv/tKBNqUkg1jsYriL7nGLVNSKFDmIyokOb/sI\nqzDQRNg/4LanH8lhrmtmCeH05Tkz3Aj1IwF8I8/fr/57Aj0DgxFSJ3aDgys2q4ld\ngIR3fe4hIDF0rXb8bAYqOt7rfl3qvbRSsLjQCi358fHRQeMGDjyC9FZ6POwdQFAP\n531uXNYnnePnuXfuSgzVBp83pW3V8rW4YkpFoPhT38msVny63EAhRcoot/2X96Cd\njRQNq/5v8G0luBv2DEDSP/CDfTZKhkMaauf8KIACLeYYNTz2gFvDfa5TroqAe5De\nHZHfqh94wyBV9wKCAQEA4pZTGWk1S0WQz01AlMvRXiM7H7jEAmddRgrpQ2w7g+Ss\nkJesYzREZ7j/kIpK3ACuQXjW/Tjlnpkp206ocCIoIwExOVG4vsewDEGaYqOvllro\n+GW7O4DhwgeUWAao/Ge1T/gu+8z/VM9N88udbc0xq8P0jn6xial9rLkhll5rZDS7\niIz1mFAzrADU5c7TvElXs86KX+T6+/sE2nNwsImaZHC1oclIHl9WnJy/qCPYFS04\nY6q9vg+vOlzRc6KgmOp/5Jex2oQsXKx45v0O8+mfLlyT6CBw4rWb0ksHC3aM8zCr\ncGmgbzqVYYIewnZ//yRm98Mty8p/m3p3iNNzHExdDQKCAQBfrel1HtZ1+x9tPi/x\n8q2IiTr4zvXjg3VxdniBKoO7Pqt9M7aNTwg3viZNy3ipjmG1ezMiD7t0+UVZ+9ia\nxi4NwggIHDZBhsQR75adXB7seIRI5qoNTKzOViNvRUkqJNPIIQvWWEw9jTOm0hPx\nTs7lUg8koBldH+H0XAwpGsnT0weMywTmKpIUAglR3N/LSyirlijzaryVHWTeylEK\nFojDhB4LyEZQa2EE3QA/FtQaOeqnI5dsvIv2gSqLVP15+dbiehV2eEdTsb3W4AoN\n3avWlFSQVDs8JMYHZbyhXX1b4hBaC8l5Fu/Y7SHC0aXu/fYpVqBPp2UFZLG2hjLc\n4yDvAoIBACzF84mz5loHVwP/ieFdHPPzFj3AbsrizeWHRmySOHhpeUfhEKlRrKqq\nPaW8DerHH6fETwcedREPxtuVAWeW+ENieu2OnmjkYH8rf2w6V/nn4N0kjQjHANUs\nVj3GoyGtBIDW08Hh0hpaFFc2RtdpkoUUZYC6vC4tla3Jrz9dTO8yFFR5NhZw0qUM\nTQVUBzbPb0sSZvln78hW47Ce2wenSSDLvLhJY7zMrfqoZp685nfYxam8FV43DzMD\nIEgvPHi67aan6vb44yM02XcbThcYdOHeXUOjFWtW44F8XdoABP4RAe9mj9MqylXI\nNnfKnqQ19zrCEIySaQC6BGC/F6Hh3QkCggEBAMQxjQVI0eUBv8C+/e9HsbvnvtPz\nBSpGdKKDvp+vfw8dP0rxCFHeDeBglTOGOB4uTUGGkU2l6HDA/pFdSOmsiXLpc/Ai\nQX4n2sj5R5W4mCiYVuHWo/BCkEF7utcwHu3raBhnYeuUooISfe2S8A/66PF9lnO9\n+FVODW6Q+qdHNH349AXwtgOS/neg16I5hw0PgMkcNuJl+bgXlyy+0O8N2/37ofb1\nbvj+34qtubGRdgtSP/EF8NxYWIz3VVqVyHtPOKoAR2Aa1ilg8ixbS1KfiqZejY6u\nTZMPvBabA8anDKtUFq7OFkzPYxMYNkL4rZGltiZMPuRRJ5RKw+yNxaLVz3M=\n-----END RSA PRIVATE KEY-----\n",
@@ -37,12 +36,12 @@ services:
                 "queue": "mails"
               },
               "redis": {
-                "host": "redist-stack",
+                "host": "redis-stack",
                 "port": 6379,
                 "username": "queue",
                 "password": "somepassword",
                 "db": 0
-              }
+              },
               "mqtt": {
                 "url": "mqtt-osem-integration:3925"
               }
@@ -54,18 +53,20 @@ services:
         }
     depends_on:
       - db
+      - redis-stack
 
   mailer:
     image: ghcr.io/opensensemap/mailer:main
+    platform: linux/amd64
     environment:
       - SMTP_HOST=mailhog
       - SMTP_PORT=1025
       - SMTP_SECURE=false
       - SMTP_USERNAME=ignored
       - SMTP_PASSWORD=ignored
-      - REDIS_HOST=localhost
+      - REDIS_HOST=redis-stack
       - REDIS_PORT=6379
-      - REDIS_USERNAME=worker
+      - REDIS_USERNAME=queue
       - REDIS_PASSWORD=somepassword
       - REDIS_DB=0
       - BULLMQ_QUEUE_NAME=mails
@@ -75,11 +76,13 @@ services:
 
   mailhog:
     image: mailhog/mailhog:v1.0.1
+    platform: linux/amd64
     ports:
       - "8025:8025"
 
   mqtt-osem-integration:
     image: ghcr.io/sensebox/mqtt-osem-integration:v0.1.0
+    platform: linux/amd64
     depends_on:
       - db
     environment:
@@ -109,7 +112,7 @@ services:
   redis-stack:
     image: redis/redis-stack-server:latest
     volumes:
-      - ./redis/local-redis-conf.stack:/redis-stack.conf
+      - ./redis/local-redis-stack.conf:/redis-stack.conf
     ports:
       - 6379:6379
 

--- a/tests/redis/local-redis-stack.conf
+++ b/tests/redis/local-redis-stack.conf
@@ -1,0 +1,33 @@
+# Redis configuration file example.
+#
+# Note that in order to read the configuration file, Redis must be
+# started with the file path as first argument:
+#
+# ./redis-server /path/to/redis.conf
+
+# Note on units: when memory size is needed, it is possible to specify
+# it in the usual form of 1k 5GB 4M and so forth:
+#
+# 1k => 1000 bytes
+# 1kb => 1024 bytes
+# 1m => 1000000 bytes
+# 1mb => 1024*1024 bytes
+# 1g => 1000000000 bytes
+# 1gb => 1024*1024*1024 bytes
+#
+# units are case insensitive so 1GB 1Gb 1gB are all the same.
+
+################################## NETWORK #####################################
+
+port 6379
+
+############################## APPEND ONLY MODE ###############################
+
+appendonly yes
+
+################################## SECURITY ###################################
+
+user queue on +@all -@dangerous +INFO ~bull:mails:* >somepassword
+user worker on +@all -@dangerous +INFO +CLIENT ~bull:mails:* >somepassword
+
+requirepass super-secret

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -9,11 +9,6 @@ const path = require('path').join(__dirname, 'tests');
 require('fs')
   .readdirSync(path)
   .forEach(function (file) {
-
-    if (file.includes('mail-test')) {
-      return;
-    }
-
     /* eslint-disable global-require */
     require(`${path}/${file}`);
     /* eslint-enable global-require */

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -9,6 +9,11 @@ const path = require('path').join(__dirname, 'tests');
 require('fs')
   .readdirSync(path)
   .forEach(function (file) {
+
+    if (file.includes('mail-test')) {
+      return;
+    }
+
     /* eslint-disable global-require */
     require(`${path}/${file}`);
     /* eslint-enable global-require */

--- a/tests/tests/ZZZ-mail-test.js
+++ b/tests/tests/ZZZ-mail-test.js
@@ -419,7 +419,7 @@ describe('mails', function () {
       let hasLink = false;
       links.each(function (_, link) {
         const href = $(link).attr('href');
-        if (href.includes('luftdaten_feinstaub.html')) {
+        if (href.includes('opensensemap-luftdaten')) {
           hasLink = true;
         }
       });
@@ -443,7 +443,7 @@ describe('mails', function () {
       let hasLink = false;
       links.each(function (_, link) {
         const href = $(link).attr('href');
-        if (href.includes('hackair_home_v2.html')) {
+        if (href.includes('opensensemap-hackair')) {
           hasLink = true;
         }
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,6 +56,11 @@
     protobufjs "^6.10.0"
     yargs "^16.1.1"
 
+"@ioredis/commands@^1.1.1":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@ioredis/commands/-/commands-1.2.0.tgz#6d61b3097470af1fdbbe622795b8921d42018e11"
+  integrity sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==
+
 "@mapbox/node-pre-gyp@^1.0.10":
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz#8e6735ccebbb1581e5a7e652244cadc8a844d03c"
@@ -70,6 +75,36 @@
     rimraf "^3.0.2"
     semver "^7.3.5"
     tar "^6.1.11"
+
+"@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.2.tgz#44d752c1a2dc113f15f781b7cc4f53a307e3fa38"
+  integrity sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==
+
+"@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.2.tgz#f954f34355712212a8e06c465bc06c40852c6bb3"
+  integrity sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==
+
+"@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.2.tgz#45c63037f045c2b15c44f80f0393fa24f9655367"
+  integrity sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==
+
+"@msgpackr-extract/msgpackr-extract-linux-arm@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.2.tgz#35707efeafe6d22b3f373caf9e8775e8920d1399"
+  integrity sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==
+
+"@msgpackr-extract/msgpackr-extract-linux-x64@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.2.tgz#091b1218b66c341f532611477ef89e83f25fae4f"
+  integrity sha512-gsWNDCklNy7Ajk0vBBf9jEx04RUxuDQfBse918Ww+Qb9HCPoGzS+XJTLe96iN3BVK7grnLiYghP/M4L8VsaHeA==
+
+"@msgpackr-extract/msgpackr-extract-win32-x64@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz#0f164b726869f71da3c594171df5ebc1c4b0a407"
+  integrity sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==
 
 "@netflix/nerror@^1.0.0":
   version "1.1.3"
@@ -620,6 +655,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
@@ -667,6 +709,20 @@ buffer@^6.0.3:
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
+
+bullmq@^3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/bullmq/-/bullmq-3.10.1.tgz#798ce661cdb9dd3acb9a5748c4e7e351a2b46edd"
+  integrity sha512-NHysIgywLRB0C1OXY1YQPXsDRnozBWBREPTyeX72ARolkHMkj0IXY+nG36N1pxc2OToPkMHyhSQxaY4jmaM0VQ==
+  dependencies:
+    cron-parser "^4.6.0"
+    glob "^8.0.3"
+    ioredis "^5.3.0"
+    lodash "^4.17.21"
+    msgpackr "^1.6.2"
+    semver "^7.3.7"
+    tslib "^2.0.0"
+    uuid "^9.0.0"
 
 cacheable-lookup@^5.0.3:
   version "5.0.3"
@@ -853,6 +909,11 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
+cluster-key-slot@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz#88ddaa46906e303b5de30d3153b7d9fe0a0c19ac"
+  integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
+
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -951,6 +1012,13 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
+cron-parser@^4.6.0:
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/cron-parser/-/cron-parser-4.8.1.tgz#47062ea63d21d78c10ddedb08ea4c5b6fc2750fb"
+  integrity sha512-jbokKWGcyU4gl6jAfX97E1gDpY12DJ1cLJZmoDzaAln/shZ+S3KBFBuA2Q6WeUN4gJf/8klnV1EfvhA2lK5IRQ==
+  dependencies:
+    luxon "^3.2.1"
+
 cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -1025,7 +1093,7 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.1.0:
+debug@4, debug@^4.1.0, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -1103,6 +1171,11 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==
+
+denque@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-2.1.0.tgz#e93e1a6569fb5e66f16a3c2a2964617d349d6ab1"
+  integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
 
 depd@~1.1.2:
   version "1.1.2"
@@ -1694,6 +1767,17 @@ glob@^7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^8.0.3:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
+
 globals@^12.1.0:
   version "12.4.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-12.4.0.tgz#a18813576a41b00a24a97e7f815918c2e19925f8"
@@ -1918,6 +2002,21 @@ inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, i
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+ioredis@^5.3.0:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.3.1.tgz#55d394a51258cee3af9e96c21c863b1a97bf951f"
+  integrity sha512-C+IBcMysM6v52pTLItYMeV4Hz7uriGtoJdz7SSBDX6u+zwSYGirLdQh3L7t/OItWITcw3gTFMjJReYUwS4zihg==
+  dependencies:
+    "@ioredis/commands" "^1.1.1"
+    cluster-key-slot "^1.1.0"
+    debug "^4.3.4"
+    denque "^2.1.0"
+    lodash.defaults "^4.2.0"
+    lodash.isarguments "^3.1.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.1.0"
 
 ip-regex@^2.0.0:
   version "2.1.0"
@@ -2165,10 +2264,20 @@ lodash.camelcase@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  integrity sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==
+
 lodash.get@4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.isarguments@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+  integrity sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==
 
 lodash.isequal@^4.5.0:
   version "4.5.0"
@@ -2210,6 +2319,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+luxon@^3.2.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.3.0.tgz#d73ab5b5d2b49a461c47cedbc7e73309b4805b48"
+  integrity sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==
 
 make-dir@^3.1.0:
   version "3.1.0"
@@ -2288,6 +2402,13 @@ minimatch@^3.0.4, minimatch@^3.1.1:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^5.0.1:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimist@^1.1.0, minimist@^1.2.5:
   version "1.2.5"
@@ -2462,6 +2583,27 @@ ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+msgpackr-extract@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/msgpackr-extract/-/msgpackr-extract-3.0.2.tgz#e05ec1bb4453ddf020551bcd5daaf0092a2c279d"
+  integrity sha512-SdzXp4kD/Qf8agZ9+iTu6eql0m3kWm1A2y1hkpTeVNENutaB0BwHlSvAIaMxwntmRUAUjon2V4L8Z/njd0Ct8A==
+  dependencies:
+    node-gyp-build-optional-packages "5.0.7"
+  optionalDependencies:
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64" "3.0.2"
+    "@msgpackr-extract/msgpackr-extract-darwin-x64" "3.0.2"
+    "@msgpackr-extract/msgpackr-extract-linux-arm" "3.0.2"
+    "@msgpackr-extract/msgpackr-extract-linux-arm64" "3.0.2"
+    "@msgpackr-extract/msgpackr-extract-linux-x64" "3.0.2"
+    "@msgpackr-extract/msgpackr-extract-win32-x64" "3.0.2"
+
+msgpackr@^1.6.2:
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/msgpackr/-/msgpackr-1.8.5.tgz#8cadfb935357680648f33699d0e833c9179dbfeb"
+  integrity sha512-mpPs3qqTug6ahbblkThoUY2DQdNXcm4IapwOS3Vm/87vmpzLVelvp9h3It1y9l1VPpiFLV11vfOXnmeEwiIXwg==
+  optionalDependencies:
+    msgpackr-extract "^3.0.1"
+
 muri@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/muri/-/muri-1.3.0.tgz#aeccf3db64c56aa7c5b34e00f95b7878527a4721"
@@ -2498,6 +2640,11 @@ node-fetch@^2.6.7:
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-gyp-build-optional-packages@5.0.7:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.7.tgz#5d2632bbde0ab2f6e22f1bbac2199b07244ae0b3"
+  integrity sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==
 
 nopt@^5.0.0:
   version "5.0.0"
@@ -2936,6 +3083,18 @@ real-require@^0.2.0:
   resolved "https://registry.yarnpkg.com/real-require/-/real-require-0.2.0.tgz#209632dea1810be2ae063a6ac084fee7e33fba78"
   integrity sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==
 
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==
+  dependencies:
+    redis-errors "^1.0.0"
+
 regexp-clone@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/regexp-clone/-/regexp-clone-0.0.1.tgz#a7c2e09891fdbf38fbb10d376fb73003e68ac589"
@@ -3128,7 +3287,7 @@ semver@^6.0.0, semver@^6.1.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.2.1, semver@^7.3.5, semver@^7.3.8:
+semver@^7.2.1, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
@@ -3320,6 +3479,11 @@ stack-trace@~0.0.9:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
   integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
+
+standard-as-callback@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz#8953fc05359868a77b5b9739a665c5977bb7df45"
+  integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
 
 static-eval@2.0.2:
   version "2.0.2"
@@ -3531,6 +3695,11 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
+tslib@^2.0.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
@@ -3618,6 +3787,11 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-compile-cache@^2.0.3:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -979,11 +979,11 @@ concat-stream@^2.0.0:
     typedarray "^0.0.6"
 
 config@^3.3.6:
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/config/-/config-3.3.6.tgz#b87799db7399cc34988f55379b5f43465b1b065c"
-  integrity sha512-Hj5916C5HFawjYJat1epbyY2PlAgLpBtDUlr0MxGLgo3p5+7kylyvnRY18PqJHgnNWXcdd0eWDemT7eYWuFgwg==
+  version "3.3.9"
+  resolved "https://registry.yarnpkg.com/config/-/config-3.3.9.tgz#27fae95b43e0e1d5723e54143c090954d8e49572"
+  integrity sha512-G17nfe+cY7kR0wVpc49NCYvNtelm/pPy8czHoFkAgtV1lkmcp7DHtWCdDu+C9Z7gb2WVqa9Tm3uF9aKaPbCfhg==
   dependencies:
-    json5 "^2.1.1"
+    json5 "^2.2.3"
 
 config@^3.3.7:
   version "3.3.7"
@@ -2156,12 +2156,10 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@^2.1.1:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
-  integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
-  dependencies:
-    minimist "^1.2.5"
+json5@^2.1.1, json5@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
 jsonpath@^1.1.1:
   version "1.1.1"
@@ -2410,10 +2408,15 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist@^1.1.0, minimist@^1.2.5:
+minimist@^1.1.0:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+minimist@^1.2.5:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 minipass@^3.0.0:
   version "3.3.4"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR removes the old `mailer` configuration and deprecated the old [mailer](https://github.com/sensebox/sensebox-mailer). We are having some trouble with the mailer written in `go` and I have no idea how to fix the issues.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I have no idea how the old mailer in go works. So I have decided to deprecate the old mailer and implement a new one written in Typescript and based on BullMQ (Redis based queue system). The new mailer is available [here](https://github.com/openSenseMap/mailer).

The queue system could also be used in other scenarios. The old mailer (go) is still configurable but is deprecated from now on.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Check out the updated tests and `docker-compose.yml` setup within the `tests` folder

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been linted using `yarn run lint`.
- [x] My code does not break the tests (`yarn run test`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
