### PR TITLE
Simple pagination for embedded boxes on user object

### DIFF
--- a/.scripts/run-tests.sh
+++ b/.scripts/run-tests.sh
@@ -22,7 +22,7 @@ only_models_tests=${only_models_tests:-}
 git_branch=$(git rev-parse --abbrev-ref HEAD)
 
 function runComposeCommand() {
-  sudo docker-compose -p osemapitest -f ./tests/docker-compose.yml "$@"
+  docker-compose -p osemapitest -f ./tests/docker-compose.yml "$@"
 }
 
 function cleanup() {

--- a/packages/api/lib/controllers/usersController.js
+++ b/packages/api/lib/controllers/usersController.js
@@ -247,12 +247,14 @@ const confirmEmailAddress = async function confirmEmailAddress (req, res) {
  * @apiName getUserBoxes
  * @apiDescription List all boxes and sharedBoxes of the signed in user with secret fields
  * @apiGroup Users
+ * @apiParam {Integer} page the selected page for pagination
  * @apiSuccess {String} code `Ok`
  * @apiSuccess {String} data A json object with a single `boxes` array field
  */
 const getUserBoxes = async function getUserBoxes (req, res) {
+  const { page } = req._userParams;
   try {
-    const boxes = await req.user.getBoxes();
+    const boxes = await req.user.getBoxes(page);
     const sharedBoxes = await req.user.getSharedBoxes();
     res.send(200, {
       code: 'Ok',
@@ -410,7 +412,12 @@ module.exports = {
     confirmEmailAddress,
   ],
   requestEmailConfirmation,
-  getUserBoxes,
+  getUserBoxes: [
+    retrieveParameters([
+      { name: 'page', dataType: 'Integer', defaultValue: 0, min: 0 }
+    ]),
+    getUserBoxes
+  ],
   updateUser: [
     checkContentType,
     retrieveParameters([

--- a/packages/api/lib/controllers/usersController.js
+++ b/packages/api/lib/controllers/usersController.js
@@ -253,13 +253,36 @@ const confirmEmailAddress = async function confirmEmailAddress (req, res) {
  */
 const getUserBoxes = async function getUserBoxes (req, res) {
   const { page } = req._userParams;
-  req.user;
   try {
     const boxes = await req.user.getBoxes(page);
     const sharedBoxes = await req.user.getSharedBoxes();
     res.send(200, {
       code: 'Ok',
       data: { boxes: boxes, boxes_count: req.user.boxes.length, sharedBoxes: sharedBoxes },
+    });
+  } catch (err) {
+    return handleError(err);
+  }
+};
+
+/**
+ * @api {get} /users/me/boxes/:boxId get specific box of the signed in user
+ * @apiName getUserBox
+ * @apiDescription Get specific box of the signed in user with secret fields
+ * @apiGroup Users
+ * @apiParam {Integer} page the selected page for pagination
+ * @apiSuccess {String} code `Ok`
+ * @apiSuccess {String} data A json object with a single `box` object field
+ */
+const getUserBox = async function getUserBox (req, res) {
+  const { boxId } = req._userParams;
+  try {
+    const box = await req.user.getBox(boxId);
+    res.send(200, {
+      code: 'Ok',
+      data: {
+        box
+      },
     });
   } catch (err) {
     return handleError(err);
@@ -413,11 +436,17 @@ module.exports = {
     confirmEmailAddress,
   ],
   requestEmailConfirmation,
+  getUserBox: [
+    retrieveParameters([
+      { predef: 'boxId', required: true }
+    ]),
+    getUserBox,
+  ],
   getUserBoxes: [
     retrieveParameters([
-      { name: 'page', dataType: 'Integer', defaultValue: 0, min: 0 }
+      { name: 'page', dataType: 'Integer', defaultValue: 0, min: 0 },
     ]),
-    getUserBoxes
+    getUserBoxes,
   ],
   updateUser: [
     checkContentType,

--- a/packages/api/lib/controllers/usersController.js
+++ b/packages/api/lib/controllers/usersController.js
@@ -253,12 +253,13 @@ const confirmEmailAddress = async function confirmEmailAddress (req, res) {
  */
 const getUserBoxes = async function getUserBoxes (req, res) {
   const { page } = req._userParams;
+  req.user;
   try {
     const boxes = await req.user.getBoxes(page);
     const sharedBoxes = await req.user.getSharedBoxes();
     res.send(200, {
       code: 'Ok',
-      data: { boxes: boxes, sharedBoxes: sharedBoxes },
+      data: { boxes: boxes, boxes_count: req.user.boxes.length, sharedBoxes: sharedBoxes },
     });
   } catch (err) {
     return handleError(err);

--- a/packages/api/lib/routes.js
+++ b/packages/api/lib/routes.js
@@ -98,6 +98,7 @@ const routes = {
     { path: `${usersPath}/me`, method: 'get', handler: usersController.getUser, reference: 'api-Users-getUser' },
     { path: `${usersPath}/me`, method: 'put', handler: usersController.updateUser, reference: 'api-Users-updateUser' },
     { path: `${usersPath}/me/boxes`, method: 'get', handler: usersController.getUserBoxes, reference: 'api-Users-getUserBoxes' },
+    { path: `${usersPath}/me/boxes/:boxId`, method: 'get', handler: usersController.getUserBox, reference: 'api-Users-getUserBox' },
     { path: `${boxesPath}/:boxId/script`, method: 'get', handler: boxesController.getSketch, reference: 'api-Boxes-getSketch' },
     { path: `${boxesPath}`, method: 'post', handler: boxesController.postNewBox, reference: 'api-Boxes-postNewBox' },
     { path: `${boxesPath}/claim`, method: 'post', handler: boxesController.claimBox, reference: 'api-Boxes-claimBox' },

--- a/packages/models/src/user/user.js
+++ b/packages/models/src/user/user.js
@@ -549,8 +549,10 @@ userSchema.methods.updateUser = function updateUser ({ email, language, name, cu
     });
 };
 
-userSchema.methods.getBoxes = function getBoxes () {
+userSchema.methods.getBoxes = function getBoxes (page) {
   return Box.find({ _id: { $in: this.boxes } })
+    .limit(25)
+    .skip(page * 25)
     .populate(Box.BOX_SUB_PROPS_FOR_POPULATION)
     .then(function (boxes) {
       return boxes.map(b => b.toJSON({ includeSecrets: true }));
@@ -561,7 +563,7 @@ userSchema.methods.getSharedBoxes = function getSharedBoxes () {
   return Box.find({ _id: { $in: this.sharedBoxes } })
     .populate(Box.BOX_SUB_PROPS_FOR_POPULATION)
     .then(function (boxes) {
-      return boxes.map(b => b.toJSON({ includeSecrets: true }));
+      return boxes.map((b) => b.toJSON({ includeSecrets: true }));
     });
 };
 

--- a/packages/models/src/user/user.js
+++ b/packages/models/src/user/user.js
@@ -559,6 +559,19 @@ userSchema.methods.getBoxes = function getBoxes (page) {
     });
 };
 
+userSchema.methods.getBox = function getBox (boxId) {
+  const user = this;
+
+  // checkBoxOwner throws ModelError
+  user.checkBoxOwner(boxId);
+
+  return Box.findOne({ _id: boxId })
+    .populate(Box.BOX_SUB_PROPS_FOR_POPULATION)
+    .then(function (box) {
+      return box.toJSON({ includeSecrets: true });
+    });
+};
+
 userSchema.methods.getSharedBoxes = function getSharedBoxes () {
   return Box.find({ _id: { $in: this.sharedBoxes } })
     .populate(Box.BOX_SUB_PROPS_FOR_POPULATION)

--- a/tests/data/getUserBoxSchema.js
+++ b/tests/data/getUserBoxSchema.js
@@ -1,0 +1,180 @@
+'use strict';
+
+module.exports = {
+  $schema: 'http://json-schema.org/draft-04/schema#',
+  type: 'object',
+  properties: {
+    code: {
+      type: 'string',
+    },
+    data: {
+      type: 'object',
+      properties: {
+        box: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              createdAt: {
+                type: 'string',
+              },
+              exposure: {
+                type: 'string',
+              },
+              model: {
+                type: 'string',
+              },
+              name: {
+                type: 'string',
+              },
+              updatedAt: {
+                type: 'string',
+              },
+              useAuth: {
+                type: 'boolean',
+              },
+              access_token: {
+                type: 'string',
+              },
+              currentLocation: {
+                type: 'object',
+                properties: {
+                  coordinates: {
+                    type: 'array',
+                    items: { type: 'number' },
+                  },
+                  timestamp: { type: 'string' },
+                  type: { type: 'string' },
+                },
+                required: ['coordinates', 'timestamp', 'type'],
+              },
+              loc: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    geometry: {
+                      type: 'object',
+                      properties: {
+                        coordinates: {
+                          type: 'array',
+                          items: {
+                            type: 'number',
+                          },
+                        },
+                        type: {
+                          type: 'string',
+                        },
+                      },
+                      required: ['coordinates', 'type'],
+                    },
+                    type: {
+                      type: 'string',
+                    },
+                  },
+                  required: ['geometry', 'type'],
+                },
+              },
+              sensors: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    title: {
+                      type: 'string',
+                    },
+                    unit: {
+                      type: 'string',
+                    },
+                    sensorType: {
+                      type: 'string',
+                    },
+                    icon: {
+                      type: 'string',
+                    },
+                    _id: {
+                      type: 'string',
+                    },
+                    lastMeasurement: {
+                      type: 'object',
+                      properties: {
+                        value: {
+                          type: 'string',
+                        },
+                        createdAt: {
+                          type: 'string',
+                        },
+                      },
+                      required: ['value', 'createdAt'],
+                    },
+                  },
+                  required: ['title', 'unit', 'sensorType', '_id'],
+                },
+              },
+              _id: {
+                type: 'string',
+              },
+              integrations: {
+                type: 'object',
+                properties: {
+                  mqtt: {
+                    type: 'object',
+                    properties: {
+                      url: {
+                        type: 'string',
+                      },
+                      topic: {
+                        type: 'string',
+                      },
+                      decodeOptions: {
+                        type: 'string',
+                      },
+                      connectionOptions: {
+                        type: 'string',
+                      },
+                      messageFormat: {
+                        type: 'string',
+                      },
+                      enabled: {
+                        type: 'boolean',
+                      },
+                    },
+                    required: ['enabled'],
+                  },
+                  ttn: {
+                    type: 'object',
+                    properties: {
+                      dev_id: {
+                        type: 'string',
+                      },
+                      app_id: {
+                        type: 'string',
+                      },
+                      profile: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+                required: ['mqtt'],
+              },
+            },
+            required: [
+              'createdAt',
+              'exposure',
+              'name',
+              'updatedAt',
+              'currentLocation',
+              'loc',
+              'sensors',
+              '_id',
+              'integrations',
+            ],
+          },
+        },
+      },
+      required: ['box'],
+    },
+  },
+  required: ['code', 'data'],
+};

--- a/tests/data/getUserBoxSchema.js
+++ b/tests/data/getUserBoxSchema.js
@@ -11,166 +11,163 @@ module.exports = {
       type: 'object',
       properties: {
         box: {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              createdAt: {
-                type: 'string',
+          type: 'object',
+          properties: {
+            createdAt: {
+              type: 'string',
+            },
+            exposure: {
+              type: 'string',
+            },
+            model: {
+              type: 'string',
+            },
+            name: {
+              type: 'string',
+            },
+            updatedAt: {
+              type: 'string',
+            },
+            useAuth: {
+              type: 'boolean',
+            },
+            access_token: {
+              type: 'string',
+            },
+            currentLocation: {
+              type: 'object',
+              properties: {
+                coordinates: {
+                  type: 'array',
+                  items: { type: 'number' },
+                },
+                timestamp: { type: 'string' },
+                type: { type: 'string' },
               },
-              exposure: {
-                type: 'string',
-              },
-              model: {
-                type: 'string',
-              },
-              name: {
-                type: 'string',
-              },
-              updatedAt: {
-                type: 'string',
-              },
-              useAuth: {
-                type: 'boolean',
-              },
-              access_token: {
-                type: 'string',
-              },
-              currentLocation: {
+              required: ['coordinates', 'timestamp', 'type'],
+            },
+            loc: {
+              type: 'array',
+              items: {
                 type: 'object',
                 properties: {
-                  coordinates: {
-                    type: 'array',
-                    items: { type: 'number' },
-                  },
-                  timestamp: { type: 'string' },
-                  type: { type: 'string' },
-                },
-                required: ['coordinates', 'timestamp', 'type'],
-              },
-              loc: {
-                type: 'array',
-                items: {
-                  type: 'object',
-                  properties: {
-                    geometry: {
-                      type: 'object',
-                      properties: {
-                        coordinates: {
-                          type: 'array',
-                          items: {
-                            type: 'number',
-                          },
-                        },
-                        type: {
-                          type: 'string',
-                        },
-                      },
-                      required: ['coordinates', 'type'],
-                    },
-                    type: {
-                      type: 'string',
-                    },
-                  },
-                  required: ['geometry', 'type'],
-                },
-              },
-              sensors: {
-                type: 'array',
-                items: {
-                  type: 'object',
-                  properties: {
-                    title: {
-                      type: 'string',
-                    },
-                    unit: {
-                      type: 'string',
-                    },
-                    sensorType: {
-                      type: 'string',
-                    },
-                    icon: {
-                      type: 'string',
-                    },
-                    _id: {
-                      type: 'string',
-                    },
-                    lastMeasurement: {
-                      type: 'object',
-                      properties: {
-                        value: {
-                          type: 'string',
-                        },
-                        createdAt: {
-                          type: 'string',
-                        },
-                      },
-                      required: ['value', 'createdAt'],
-                    },
-                  },
-                  required: ['title', 'unit', 'sensorType', '_id'],
-                },
-              },
-              _id: {
-                type: 'string',
-              },
-              integrations: {
-                type: 'object',
-                properties: {
-                  mqtt: {
+                  geometry: {
                     type: 'object',
                     properties: {
-                      url: {
-                        type: 'string',
+                      coordinates: {
+                        type: 'array',
+                        items: {
+                          type: 'number',
+                        },
                       },
-                      topic: {
+                      type: {
                         type: 'string',
-                      },
-                      decodeOptions: {
-                        type: 'string',
-                      },
-                      connectionOptions: {
-                        type: 'string',
-                      },
-                      messageFormat: {
-                        type: 'string',
-                      },
-                      enabled: {
-                        type: 'boolean',
                       },
                     },
-                    required: ['enabled'],
+                    required: ['coordinates', 'type'],
                   },
-                  ttn: {
-                    type: 'object',
-                    properties: {
-                      dev_id: {
-                        type: 'string',
-                      },
-                      app_id: {
-                        type: 'string',
-                      },
-                      profile: {
-                        type: 'string',
-                      },
-                    },
+                  type: {
+                    type: 'string',
                   },
                 },
-                required: ['mqtt'],
+                required: ['geometry', 'type'],
               },
             },
-            required: [
-              'createdAt',
-              'exposure',
-              'name',
-              'updatedAt',
-              'currentLocation',
-              'loc',
-              'sensors',
-              '_id',
-              'integrations',
-            ],
+            sensors: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  title: {
+                    type: 'string',
+                  },
+                  unit: {
+                    type: 'string',
+                  },
+                  sensorType: {
+                    type: 'string',
+                  },
+                  icon: {
+                    type: 'string',
+                  },
+                  _id: {
+                    type: 'string',
+                  },
+                  lastMeasurement: {
+                    type: 'object',
+                    properties: {
+                      value: {
+                        type: 'string',
+                      },
+                      createdAt: {
+                        type: 'string',
+                      },
+                    },
+                    required: ['value', 'createdAt'],
+                  },
+                },
+                required: ['title', 'unit', 'sensorType', '_id'],
+              },
+            },
+            _id: {
+              type: 'string',
+            },
+            integrations: {
+              type: 'object',
+              properties: {
+                mqtt: {
+                  type: 'object',
+                  properties: {
+                    url: {
+                      type: 'string',
+                    },
+                    topic: {
+                      type: 'string',
+                    },
+                    decodeOptions: {
+                      type: 'string',
+                    },
+                    connectionOptions: {
+                      type: 'string',
+                    },
+                    messageFormat: {
+                      type: 'string',
+                    },
+                    enabled: {
+                      type: 'boolean',
+                    },
+                  },
+                  required: ['enabled'],
+                },
+                ttn: {
+                  type: 'object',
+                  properties: {
+                    dev_id: {
+                      type: 'string',
+                    },
+                    app_id: {
+                      type: 'string',
+                    },
+                    profile: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+              required: ['mqtt'],
+            },
           },
+          required: [
+            'createdAt',
+            'exposure',
+            'name',
+            'updatedAt',
+            'currentLocation',
+            'loc',
+            'sensors',
+            '_id',
+            'integrations',
+          ],
         },
       },
       required: ['box'],

--- a/tests/tests/005-create-boxes-test.js
+++ b/tests/tests/005-create-boxes-test.js
@@ -216,12 +216,14 @@ describe('openSenseMap API Routes: /boxes', function () {
     let boxId;
 
     return chakram
-      .get(`${BASE_URL}/user/me/boxes`, {
+      .get(`${BASE_URL}/users/me/boxes`, {
         headers: { Authorization: `Bearer ${jwt}` },
       })
       .then(function (response) {
         expect(response).to.have.status(200);
         expect(response).to.have.schema(getUserBoxesSchema);
+
+        return response;
       })
       .then(function (response) {
         boxId = response.body.data.boxes[0]._id;
@@ -735,25 +737,40 @@ describe('openSenseMap API Routes: /boxes', function () {
   it('should deny to retrieve a box of other user', function () {
     let otherJwt, otherBoxId;
 
-    return chakram.post(`${BASE_URL}/users/sign-in`, { name: 'mrtest2', email: 'tester3@test.test', passwort: '12345678' })
+    return chakram
+      .post(`${BASE_URL}/users/sign-in`, {
+        name: 'mrtest2',
+        email: 'tester3@test.test',
+        password: '12345678',
+      })
       .then(function (response) {
         expect(response).to.have.status(200);
-        expect(response).to.have.header('content-type', 'application/json; charset=utf-8');
+        expect(response).to.have.header(
+          'content-type',
+          'application/json; charset=utf-8'
+        );
 
         expect(response.body.token).to.exist;
 
         otherJwt = response.body.token;
 
-        return chakram.get(`${BASE_URL}/users/me/boxes`, { headers: { 'Authorization': `Bearer ${otherJwt}` } });
+        return chakram.get(`${BASE_URL}/users/me/boxes`, {
+          headers: { Authorization: `Bearer ${otherJwt}` },
+        });
       })
       .then(function (response) {
         otherBoxId = response.body.data.boxes[0]._id;
 
-        return chakram.get(`${BASE_URL}/users/me/boxes/${otherBoxId}`, { headers: { 'Authorization': `Bearer ${jwt}` } });
+        return chakram.get(`${BASE_URL}/users/me/boxes/${otherBoxId}`, {
+          headers: { Authorization: `Bearer ${jwt}` },
+        });
       })
       .then(function (response) {
         expect(response).to.have.status(403);
-        expect(response).to.have.json({ code: 'Forbidden', message: 'User does not own this senseBox' });
+        expect(response).to.have.json({
+          code: 'Forbidden',
+          message: 'User does not own this senseBox',
+        });
       });
   });
 

--- a/tests/tests/005-create-boxes-test.js
+++ b/tests/tests/005-create-boxes-test.js
@@ -12,6 +12,7 @@ const BASE_URL = process.env.OSEM_TEST_BASE_URL,
   senseBoxSchema = require('../data/senseBoxSchema'),
   getUserSchema = require('../data/getUserSchema'),
   getUserBoxesSchema = require('../data/getUserBoxesSchema'),
+  getUserBoxSchema = require('../data/getUserBoxSchema'),
   custom_valid_sensebox = require('../data/custom_valid_sensebox');
 
 describe('openSenseMap API Routes: /boxes', function () {
@@ -208,6 +209,30 @@ describe('openSenseMap API Routes: /boxes', function () {
         expect(response).to.comprise.of.json('data.sharedBoxes.0.integrations.mqtt', { enabled: false });
 
         return chakram.wait();
+      });
+  });
+
+  it('should let users retrieve one of their boxes with all fields', function () {
+    let boxId;
+
+    return chakram
+      .get(`${BASE_URL}/user/me/boxes`, {
+        headers: { Authorization: `Bearer ${jwt}` },
+      })
+      .then(function (response) {
+        expect(response).to.have.status(200);
+        expect(response).to.have.schema(getUserBoxesSchema);
+      })
+      .then(function (response) {
+        boxId = response.body.data.boxes[0]._id;
+
+        return chakram.get(`${BASE_URL}/users/me/boxes/${boxId}`, {
+          headers: { Authorization: `Bearer ${jwt}` },
+        });
+      })
+      .then(function (response) {
+        expect(response).to.have.status(200);
+        expect(response).to.have.schema(getUserBoxSchema);
       });
   });
 
@@ -700,6 +725,31 @@ describe('openSenseMap API Routes: /boxes', function () {
         otherBoxId = response.body.data.boxes[0]._id;
 
         return chakram.get(`${BASE_URL}/boxes/${otherBoxId}/script`, { headers: { 'Authorization': `Bearer ${jwt}` } });
+      })
+      .then(function (response) {
+        expect(response).to.have.status(403);
+        expect(response).to.have.json({ code: 'Forbidden', message: 'User does not own this senseBox' });
+      });
+  });
+
+  it('should deny to retrieve a box of other user', function () {
+    let otherJwt, otherBoxId;
+
+    return chakram.post(`${BASE_URL}/users/sign-in`, { name: 'mrtest2', email: 'tester3@test.test', passwort: '12345678' })
+      .then(function (response) {
+        expect(response).to.have.status(200);
+        expect(response).to.have.header('content-type', 'application/json; charset=utf-8');
+
+        expect(response.body.token).to.exist;
+
+        otherJwt = response.body.token;
+
+        return chakram.get(`${BASE_URL}/users/me/boxes`, { headers: { 'Authorization': `Bearer ${otherJwt}` } });
+      })
+      .then(function (response) {
+        otherBoxId = response.body.data.boxes[0]._id;
+
+        return chakram.get(`${BASE_URL}/users/me/boxes/${otherBoxId}`, { headers: { 'Authorization': `Bearer ${jwt}` } });
       })
       .then(function (response) {
         expect(response).to.have.status(403);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds a simple pagination functionality to the `/users/me/boxes` endpoint and introduces a new endpoint at `/users/me/boxes/:boxId` to retrieve a specific box of a logged in user.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Right now the API performs pretty slow on this request if the users has more than 100 boxes in his account. All boxes are populated and that takes time. Therefore a new parameter `page` is introduced and the result is limited to 25 boxes. To paginate through all included boxes increase the `page` parameter to get the next results.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test have been added to the testsuite.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been linted using `yarn run lint`.
- [x] My code does not break the tests (`yarn run test`)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
