### PR TITLE
(docs): clarify longitude and latitude order

### DIFF
--- a/packages/api/lib/helpers/userParamHelpers.js
+++ b/packages/api/lib/helpers/userParamHelpers.js
@@ -330,7 +330,7 @@ const validateAndCastParam = function validateAndCastParam ({ value, dataType, a
  * @apiParam (LocationOption) {Number} [height] Height above ground in meters.
  *
  * @apiParamExample {application/json} Location Object:
- * { "lat": 51.972, "lng": 7.684, "height": 66.6 }
+ * { "lng": 7.684, "lat": 51.972, "height": 66.6 }
  *
  * @apiParamExample {application/json} Location Array:
  * [7.684, 51.972, 66.6]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We have specified `latitude` and `longitude` order in different ways in our documentation. This PR unifies the order to `lng,lat,height`.

Closes #360

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (updates and clarifications)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been linted using `yarn run lint`.
- [x] My code does not break the tests (`yarn run test`)
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
