### PR TITLE
Return correct response if user was not updated

### DIFF
--- a/packages/models/src/user/user.js
+++ b/packages/models/src/user/user.js
@@ -539,6 +539,10 @@ userSchema.methods.updateUser = function updateUser ({ email, language, name, cu
       return user.save();
     })
     .then(function (updatedUser) {
+      if (updatedUser.updated === false) {
+        return updatedUser;
+      }
+
       return { updated: true, signOut, messages: msgs, updatedUser };
     })
     .catch(function (err) {

--- a/tests/tests/004-users-test.js
+++ b/tests/tests/004-users-test.js
@@ -197,6 +197,24 @@ describe('openSenseMap API Routes: /users', function () {
       });
   });
 
+  it('should return that no changed properties are applied and user remains unchanged', function () {
+    return chakram
+      .put(
+        `${BASE_URL}/users/me`,
+        { name: 'new Name' },
+        { headers: { Authorization: `Bearer ${jwt}` } }
+      )
+      .then(function (response) {
+        expect(response).to.have.status(200);
+        expect(response).to.have.json(
+          'message',
+          'No changed properties supplied. User remains unchanged.'
+        );
+
+        return chakram.wait();
+      });
+  });
+
   it('should deny to change name to existing name', function () {
     return chakram.put(`${BASE_URL}/users/me`, { name: 'this is just a nickname', currentPassword: '12345678' }, { headers: { 'Authorization': `Bearer ${jwt}` } })
       .then(function (response) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The API returned a wrong response when updating a user with no changed values.

Closes #778 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
One test case was added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been linted using `yarn run lint`.
- [x] My code does not break the tests (`yarn run test`)
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
