### PR TITLE
Add support to SCD30 CO2 sensor coming through Luftdaten firmware

### DIFF
--- a/packages/models/src/measurement/decoding/luftdatenHandler.js
+++ b/packages/models/src/measurement/decoding/luftdatenHandler.js
@@ -78,6 +78,7 @@ const matchings = {
   n5: ['nc5', 'n5'],
   n10: ['nc10', 'n10'],
   n25: ['nc2.5', 'n2.5'],
+  co2_ppm: ['co2', 'carbon_dioxide', 'kohlendioxid', 'kohlenstoffdioxid'],
   temperature: ['temperatur'],
   humidity: ['rel. luftfeuchte', 'luftfeuchtigkeit', 'luftfeuchte'],
   pressure: ['luftdruck', 'druck'],

--- a/packages/models/src/measurement/decoding/luftdatenHandler.js
+++ b/packages/models/src/measurement/decoding/luftdatenHandler.js
@@ -78,6 +78,7 @@ const matchings = {
   n5: ['nc5', 'n5'],
   n10: ['nc10', 'n10'],
   n25: ['nc2.5', 'n2.5'],
+  co2: ['co2', 'carbon_dioxide', 'kohlendioxid', 'kohlenstoffdioxid'],
   co2_ppm: ['co2', 'carbon_dioxide', 'kohlendioxid', 'kohlenstoffdioxid'],
   temperature: ['temperatur'],
   humidity: ['rel. luftfeuchte', 'luftfeuchtigkeit', 'luftfeuchte'],


### PR DESCRIPTION
## Description

Luftdaten firmware sends SCD30 sensor data as `scd30_co2_ppm`, which currently can't be matched to a sensor title.

## Motivation and Context

With this addition, if you name a sensor phenomenon 'co2', 'carbon_dioxide', 'kohlendioxid', 'kohlenstoffdioxid' it will match against the sensor data sent by Luftdaten firmware.

## How Has This Been Tested?

Luftdaten firmware provides debug info on the JSON sent. Example JSON measurement:
```
Data to send: {"software_version": "NRZ-2024-135", "sensordatavalues":
[{"value_type":"SCD30_temperature","value":"27.08"},{"value_type":"SCD30_humidity","value":"46.97"},
{"value_type":"SCD30_co2_ppm","value":"579.00"},{"value_type":"samples","value":"1089060"},
{"value_type":"min_micro","value":"25"},{"value_type":"max_micro","value":"93121"},
{"value_type":"interval","value":"30000"},{"value_type":"signal","value": [...]
```

Of which the `{"value_type":"SCD30_co2_ppm","value":"579.00"}` is the key. `luftdatenHandler.js` will split at the first underscore and try to match `co2_ppm` to a Phenomenon textbox value defined by the user.

## Types of changes

`luftdatenHandler.js` matchings enum has two new entries for co2 and co2_ppm phenomenon and likely user-defined titles.

## Checklist:
- [X] My code has been linted using `yarn run lint`.
- [X] My code does not break the tests (`yarn run test`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
